### PR TITLE
Comment to show that Placeholder is HTML5.

### DIFF
--- a/includes/qcubed/_core/base_controls/QTextBoxBase.class.php
+++ b/includes/qcubed/_core/base_controls/QTextBoxBase.class.php
@@ -20,7 +20,7 @@
 	 * @property string $LabelForTooShortUnnamed
 	 * @property string $LabelForTooLong
 	 * @property string $LabelForTooLongUnnamed
-	 * @property string $Placeholder
+	 * @property string $Placeholder HTML5 Only. Placeholder text that gets erased once a user types.
 	 * @property string $CrossScripting can be Allow, HtmlEntities, or Deny.  Deny is the default. Prevents cross scripting hacks.  HtmlEntities causes framework to automatically call php function htmlentities on the input data.  Allow allows everything to come through without altering at all.  USE "ALLOW" judiciously: using ALLOW on text entries, and then outputting that data WILL allow hackers to perform cross scripting hacks.
 	 * @property integer $MaxLength is the "maxlength" html attribute (applicable for SingleLine textboxes)
 	 * @property integer $MinLength is the minimum requred length to pass validation


### PR DESCRIPTION
We should be documenting all HTML5 only additions to the objects. We have not made HTML5 only changes in the past. In general, QCubed has tried to make all features of all the widgets available to all browsers supported. As far as I know, this will be the first browser specific change. If someone wants to, they could add the js code so that all browsers can support Placeholder. Also, this is not a jquery-ui change. In the future, we should be putting changes that are not related to the designated feature into a separate branch.
