### PR TITLE
Fixed bug for postgres installation.

### DIFF
--- a/assets/_core/php/examples/datagrid/advanced_filtering.php
+++ b/assets/_core/php/examples/datagrid/advanced_filtering.php
@@ -129,9 +129,9 @@ class ExampleForm extends QForm {
 	protected function dtgCustom_Bind()	{
 		//Set up our normal query
 		$sql = 'SELECT
-					p.first_name as FirstName,
-					p.last_name as LastName,
-					count(a.id) as AddressCount
+					p.first_name as "FirstName",
+					p.last_name as "LastName",
+					count(a.id) as "AddressCount"
 				FROM person as p
 					LEFT JOIN address as a on a.person_id = p.id
 				GROUP BY p.id';


### PR DESCRIPTION
This example is broken on postgres. PoatgreSQL don't preserve the case of aliases. It must be wrapped with double quotes for this.
