### PR TITLE
Fixes change to accordion api from jquery-ui

### DIFF
--- a/includes/qcubed/_core/base_controls/QAccordionBase.class.php
+++ b/includes/qcubed/_core/base_controls/QAccordionBase.class.php
@@ -68,8 +68,8 @@
 			$strJS = parent::GetControlJavaScript();
 			
 			$strJS .=<<<FUNC
-			.on("accordionchange", function(event, ui) {
-			 			qcubed.recordControlModification("$this->ControlId", "_SelectedIndex", ui.options.active);
+			.on("accordionactivate", function(event, ui) {
+			 			qcubed.recordControlModification("$this->ControlId", "_SelectedIndex", jQuery(this).accordion("option", "active"));
 						qc.pA("$formId", "$this->ControlId", "QChangeEvent", "", "");
 			})						
 FUNC;


### PR DESCRIPTION
Looks like there was a change to the accordion api. Some of the events have been removed, and in particular, accordionchange. This is now accordionactivate.
