### PR TITLE
Corrected the PHPDoc comments in QTextBoxBase class

### DIFF
--- a/includes/qcubed/_core/base_controls/QTextBoxBase.class.php
+++ b/includes/qcubed/_core/base_controls/QTextBoxBase.class.php
@@ -6,8 +6,8 @@
 	 */
 
 	/**
-	 * This class will render an HTML Textbox -- which can either be <input type="text">,
-	 * <input type="password"> or <textarea> depending on the TextMode (see below).
+	 * This class will render an HTML Textbox -- which can either be [input type="text"],
+	 * [input type="password"] or [textarea] depending on the TextMode (see below).
 	 *
 	 * @package Controls
 	 *


### PR DESCRIPTION
QTextBoxBase class had PHPDoc comments in the head which were causing problems in the generated result when PHPDocumentor ran over the codebaase. Changes in this pull request fix that.
