### PR TITLE
Feature-Autocomplete Improvements

### DIFF
--- a/assets/_core/js/qAutocomplete.js
+++ b/assets/_core/js/qAutocomplete.js
@@ -1,0 +1,102 @@
+/**
+ * qAutocomplete.js
+ * 
+ * Javascript to empower a QAutocomplete to have a variety of behaviors. These javascript routines
+ * are in this separate file so that they are included only once.
+ * 
+ */
+
+function qAutocomplete (qOptions) {
+	var jqObj = jQuery('#' + qOptions['controlId']);
+	jqObj.data('qOptions', qOptions);
+	
+	if (qOptions['multiValDelim']) {
+		// This is an adaptation from code found on the JQuery UI Autocomplete Web site. 
+		// Its not the best multi-item selector, but it DOES support Ajax.
+		
+		// Note that since this is a multi-select, updating SelectedId is not meningful
+		// don't navigate away from the field on tab when selecting an item.
+		jqObj.bind("keydown", function(event) {
+			if (event.keyCode === jQuery.ui.keyCode.TAB && jQuery(this).data("autocomplete").menu.active) {
+				event.preventDefault();
+			}
+		})
+		.data("delimExp", new RegExp (qOptions['multiValDelim'] + "\\s*", "g"))
+		.data("curTerm", function (el, newVal) {
+			// if newVal is present, replaces that term with newVal and returns the full value of the field
+			// if no newVal, returns just the current term
+			var jqObj = jQuery(el);
+			var curVal = jqObj.val();
+			var delimExp = jqObj.data('delimExp');
+			var delim = jqObj.data('qOptions')['multiValDelim'];
+			
+			// get caret position
+			var caretPos = 0;
+			if (document.selection) { // IE
+				el.focus();
+				var range = document.selection.createRange();
+				range.moveStart("character", -curVal.length);
+				caretPos = range.text.length;
+			} else if (el.selectionStart) { // MOZ
+				caretPos = el.selectionStart;
+			}
+			// find which term the caret is in
+			var matches = curVal.substring(0, caretPos).match(delimExp);
+			var termIdx = matches ? matches.length : 0;
+			var terms = curVal.split(delimExp);
+			if (termIdx >= terms.length) {
+				termIdx = terms.length;
+				terms.push("");
+			}
+			if (newVal !== undefined) { // setting the value
+				if (newVal !== null)
+					terms[termIdx] = newVal;
+				else
+					terms.splice(termIdx, 1);
+				if (terms.length && terms[terms.length-1]) {
+					terms.push("");
+				}
+				return terms.join(delim + ' ');
+			}
+			return terms[termIdx];
+		})
+		.on("autocompleteselect", function (event, ui) {
+			var sel = ui.item ? (ui.item.value ? ui.item.value : ui.item.label) : "";
+			this.value = jQuery(this).data("curTerm")(this, sel);
+			return false;
+		})
+		.on("autocompletefocus", function () {
+			return false;
+		});
+	} else {
+		jqObj.on("autocompleteselect", function (event, ui) {
+		    qcubed.recordControlModification(this.id, "SelectedId", ui.item.id);
+		})
+		.on("autocompletefocus", function (event, ui) {
+			if ( /^key/.test(event.originalEvent.type) ) {
+		 		qcubed.recordControlModification(this.id, "SelectedId", ui.item.id);
+			}
+		})
+		.on("autocompletechange", function( event, ui ) {
+			var toTest = ui.item ? (ui.item.value ? ui.item.value : ui.item.label) : '';
+			if ( !ui.item ||
+				jQuery( this ).val() != toTest) {
+					// remove invalid value, as no match 
+					if (jQuery(this).data("qOptions")["mustMatch"]) {
+						jQuery( this ).val( "" );
+						jQuery( this ).data( "autocomplete" ).term = '';
+					}
+					qcubed.recordControlModification(this.id, "SelectedId", '');
+			}
+		});
+	};
+	
+	if (qOptions['displayHtml']) {
+		jqObj.data( "autocomplete" )._renderItem = function( ul, item ) {
+            return jQuery( "<li>" )
+	            .data( "item.autocomplete", item )
+	            .append( jQuery( "<a></a>" ).html(item.label) )
+	            .appendTo( ul );
+	    };
+	};
+}

--- a/assets/_core/php/examples/other_controls/jq_example.php
+++ b/assets/_core/php/examples/other_controls/jq_example.php
@@ -17,9 +17,12 @@
 		protected $Accordion;
 		/** @var QAutocomplete */
 		protected $Autocomplete1;
+		/** @var QAutocomplete */
 		protected $Autocomplete2;
 		/** @var QAutocomplete */
 		protected $AjaxAutocomplete;
+		/** @var QAutocomplete */
+		protected $AjaxAutocomplete2;
 		/** @var QJqButton */
 		protected $Button;
 		/** @var QJqCheckBox */
@@ -144,7 +147,14 @@
 			$this->AjaxAutocomplete = new QAutocomplete($this);
 			$this->AjaxAutocomplete->SetDataBinder("update_autocompleteList");
 			$this->AjaxAutocomplete->AddAction (new QAutocomplete_ChangeEvent(), new QAjaxAction ('ajaxautocomplete_change'));
-
+			$this->AjaxAutocomplete->DisplayHtml = true;
+			$this->AjaxAutocomplete->Name = 'With Html Display';
+			
+			$this->AjaxAutocomplete2 = new QAutocomplete($this);
+			$this->AjaxAutocomplete2->MultipleValueDelimiter = ',';
+			$this->AjaxAutocomplete2->SetDataBinder("update_autocompleteList");
+			$this->AjaxAutocomplete2->Name = 'Multiple selection';
+			
 			// Button
 			$this->Button = new QJqButton($this);
 			$this->Button->Label = "Click me";	// Label overrides Text
@@ -232,28 +242,38 @@
 			$this->Tabs->Headers = array('One', 'Two', 'Three');
 		}
 
-		protected function update_autocompleteList() {
-			$strTyped = $this->AjaxAutocomplete->Text;
+		protected function update_autocompleteList($strFormId, $strControlId, $strParameter) {
+			$strLookup = $strParameter;
+			$objControl = $this->GetControl ($strControlId);
 			
 			$cond = QQ::OrCondition (
-						QQ::Like (QQN::Person()->FirstName, '%' . $strTyped . '%'),
-						QQ::Like (QQN::Person()->LastName, '%' . $strTyped . '%')
+						QQ::Like (QQN::Person()->FirstName, '%' . $strLookup . '%'),
+						QQ::Like (QQN::Person()->LastName, '%' . $strLookup . '%')
 					);
 					
 			$clauses[] = QQ::OrderBy (QQN::Person()->LastName, QQN::Person()->FirstName);
 					
 			$lst = Person::QueryArray ($cond, $clauses);
 			
-			// If you implement Person::__toString in the model->Person.class.php file, you 
-			// could just pass the $lst to the DataSource.
-			// Instead, we will  build the list using autcomplete list items
+			/*
+			 * If you implement Person::__toString in the model->Person.class.php file, you
+			 * could just pass the $lst to the DataSource. If you want to add a 'label' item
+			 * to the display, you can override toJsObject in the People.class.php file.
+			 * 
+			 * For puposes of this example, we will build a custom list using list items below.
+			 * 
+			 */  
 			
 			//$this->AjaxAutocomplete->DataSource = $lst; 
 			$a = array();
 			foreach ($lst as $objPerson) {
-				$a[] = new QListItem ($objPerson->FirstName . ' ' . $objPerson->LastName, $objPerson->Id);
+				$item = new QListItem ($objPerson->FirstName . ' ' . $objPerson->LastName, $objPerson->Id);
+				if ($objControl->DisplayHtml) {
+					$item->Label = '<em>' . $objPerson->FirstName . ' ' . $objPerson->LastName . '</em>';
+				}
+				$a[] = $item;
 			}
-			$this->AjaxAutocomplete->DataSource = $a;
+			$objControl->DataSource = $a;
 		}
 		
 		protected function ajaxautocomplete_change() {

--- a/assets/_core/php/examples/other_controls/jq_example.tpl.php
+++ b/assets/_core/php/examples/other_controls/jq_example.tpl.php
@@ -1,5 +1,5 @@
 <?php require('../includes/header.inc.php'); ?>
-<?php $this->RenderBegin(); ?>
+	<?php $this->RenderBegin(); ?>
 
 <div id="instructions">
 	<h1>jQuery Controls: Server-Side Wrappers</h1>
@@ -59,7 +59,8 @@
 	
 	<div class="example"><h2>Ajax Autocomplete</h2>
 		 <p>Type "s" to test</p>
-		<?php $this->AjaxAutocomplete->Render(); ?>
+			<?php $this->AjaxAutocomplete->RenderWithName(); ?>
+			<?php $this->AjaxAutocomplete2->RenderWithName(); ?>
 	</div>
 	
 	<div class="example"><h2>Buttons</h2>

--- a/includes/qcubed/_core/base_controls/QAutocompleteBase.class.php
+++ b/includes/qcubed/_core/base_controls/QAutocompleteBase.class.php
@@ -53,14 +53,16 @@
 	 * you to use an array of QListItems, or an array of database objects as the source. You can also pass this array
 	 * statically in the Source parameter at creation time, or dynamically via Ajax by using SetDataBinder, and then
 	 * in your data binder function, setting the DataSource parameter.
-	 *
+	 * 
 	 * @property string $SelectedId the id of the selected item. When QAutocompleteListItem objects are used for the DataSource, this corresponds to the Value of the item
 	 * @property boolean $MustMatch if true, non matching values are not accepted by the input
 	 * @property string $MultipleValueDelimiter if set, the Autocomplete will keep appending the new selections to the previous term, delimited by this string.
 	 *    This is useful when making QAutocomplete handle multiple values (see http://jqueryui.com/demos/autocomplete/#multiple ).
-	 * @property-write array $DataSource an array of strings, QAutocompleteListItem's,
-	 * 
+	 * @property boolean $DisplayHtml if set, the Autocomplete will treat the 'label' portion of each data item as Html.
+	 * @property-write array $Source an array of strings, QListItem's, or data objects. To be used at creation time. {@inheritdoc }
+	 * @property-write array $DataSource an array of strings, QListItem's, or data objects
 	 * @link http://jqueryui.com/autocomplete/
+	 * @access private
 	 * @package Controls\Base
 	 */
 	class QAutocompleteBase extends QAutocompleteGen
@@ -75,7 +77,11 @@
 		protected $blnMustMatch = false;
 		/** @var string */
 		protected $strMultipleValueDelimiter = null;
+		/** @var boolean */
+		protected $blnDisplayHtml = false;
 
+		protected $strJavaScripts = 'qAutocomplete.js';
+		
 		
 		/**
 		 * When this filter is passed to QAutocomplete::UseFilter, only the items in the source list that contain the typed term will be shown in the drop-down
@@ -115,17 +121,30 @@
 		}
 
 
-		// Set up an Ajax data binder. 
-		public function SetDataBinder($strMethodName, $objParentControl = null, $blnReturnTermAsParameter = false) {
+		/**
+		 * Set the data binder for ajax filtering
+		 * 
+		 * Call this at creation time to set the data binder of the item list you will display. The data binder 
+		 * will be an AjaxAction function, and so will receive the following parameters:
+		 * - FormId
+		 * - ControlId
+		 * - Parameter
+		 * 
+		 * The Parameter in particular will be the term that you should use for filtering. There are situations
+		 * where the term will not be the same as the contents of the field.
+		 * 
+		 * @param string $strMethodName The name of the method to call
+		 * @param QControl $objParentControl The control which contains the method, if the method is not in the form
+		 */ 
+		public function SetDataBinder($strMethodName, $objParentControl = null) {
 			$strJsReturnParam = '';
 			$strBody = '';
-			if ($blnReturnTermAsParameter) {
-				if ($this->MultipleValueDelimiter) {
-					$strJsReturnParam = 'this.element.data("splitterFunc")(this.element.get(0))';
-				} else {
-					$strJsReturnParam = 'request.term';
-				}
+			if ($this->MultipleValueDelimiter) {
+				$strJsReturnParam = 'this.element.data("curTerm")(this.element.get(0))';
+			} else {
+				$strJsReturnParam = 'request.term';
 			}
+			
 			if ($objParentControl) {
 				$objAction = new QAjaxControlAction($objParentControl, $strMethodName, 'default', null, $strJsReturnParam);
 			} else {
@@ -152,100 +171,20 @@
 
 		// These functions are used to keep track of the selected value, and to implement
 		// optional autocomplete functionality.
-		
 		public function GetControlJavaScript() {
 			$strJS = parent::GetControlJavaScript();
-			$strValueExpr = 'var value = jQuery(this).val();';
-			$strResetValue = 'var resetValue = "";';
+			$options = array();
+			$options['controlId'] = $this->ControlId;
 			if ($this->strMultipleValueDelimiter) {
-				// don't navigate away from the field on tab when selecting an item
-				$strJS .= '.bind("keydown", function(event) {
-								if (event.keyCode === jQuery.ui.keyCode.TAB && jQuery(this).data("autocomplete").menu.active) {
-									event.preventDefault();
-								}
-							})';
-				$strEscapedDelimiter = preg_quote($this->strMultipleValueDelimiter);
-				$strSplitFunc =sprintf('
-				// splits the value in element el into terms using the delimiter
-				// finds and returns the term at the caret
-				// if the second argument is present replaces that term with val and returns the full (modified) value
-				function (el, val) {
-					var value = jQuery(el).val();
-					// get caret position
-					var caretPos = 0;
-					if (document.selection) { // IE
-						el.focus();
-						var range = document.selection.createRange();
-						range.moveStart("character", -value.length);
-						caretPos = range.text.length;
-					} else if (el.selectionStart) { // MOZ
-						caretPos = el.selectionStart;
-					}
-					// find which term the caret is in
-					var matches = value.substring(0, caretPos).match(/%s\s*/g);
-					var termIdx = matches ? matches.length : 0;
-					var terms = value.split(/%s\s*/);
-					if (termIdx >= terms.length) {
-						termIdx = terms.length;
-						terms.push("");
-					}
-					if (val !== undefined) { // setting the value
-						if (val !== null)
-							terms[termIdx] = val;
-						else
-							terms.splice(termIdx, 1);
-						if (terms.length && terms[terms.length-1]) {
-							terms.push("");
-						}
-						return terms.join("%s ");
-					}
-					return terms[termIdx];
-				}', $strEscapedDelimiter, $strEscapedDelimiter, $this->MultipleValueDelimiter);
-				$strJS .= '.data("splitterFunc", '.$strSplitFunc.')';
-				$strValueExpr = 'var splitterFunc = jQuery(this).data("splitterFunc"); var value = splitterFunc(this);';
-				$strResetValue = 'var resetValue = splitterFunc(this, null);';
-
-				$strJS .=sprintf('.on("autocompleteselect",
-				function (event, ui) {
-					var sel = ui.item ? (ui.item.value ? ui.item.value : ui.item.label) : "";
-					this.value = jQuery(this).data("splitterFunc")(this, sel);
-					return false;
-				})', preg_quote($this->strMultipleValueDelimiter), $this->strMultipleValueDelimiter);
-
-				$strJS .= '.on("autocompletefocus",
-				function () {
-					return false;
-				})';
-			} else {
-				$strJS .=sprintf('.on("autocompleteselect",
-				function (event, ui) {
-				    qcubed.recordControlModification("%s", "SelectedId", ui.item.id);
-				})', $this->ControlId);
-
-				$strJS .=sprintf('
-				.on("autocompletefocus",
-				function (event, ui) {
-					if ( /^key/.test(event.originalEvent.type) ) {
-				 		qcubed.recordControlModification("%s", "SelectedId", ui.item.id);
-					}
-				})', $this->ControlId);
+				$options['multiValDelim'] = $this->strMultipleValueDelimiter;
 			}
-
-			$strMustMatch = $this->blnMustMatch ? sprintf('// remove invalid value, as no match
-									%s
-									jQuery( this ).val(resetValue);
-									jQuery( this ).data( "autocomplete" ).term = "";
-			', $strResetValue) : '';
-
-			$strJS .=sprintf('
-			.on("autocompletechange", function( event, ui ) {
-				var toTest = ui.item ? (ui.item.value ? ui.item.value : ui.item.label) : "";
-				%s
-				if ( !ui.item || value != toTest) {
-					%s
-		 			qcubed.recordControlModification("%s", "SelectedId", "");
-				}
-			})', $strValueExpr, $strMustMatch, $this->ControlId);
+			if ($this->blnMustMatch) {
+				$options['mustMatch'] = 1;
+			}
+			if ($this->blnDisplayHtml) {
+				$options['displayHtml'] = 1;
+			}
+			$strJS .= ';qAutocomplete(' . JavaScriptHelper::toJsObject($options) . ')';
 			
 			return $strJS;
 		}
@@ -258,7 +197,10 @@
 			QApplication::ExecuteJavaScript($strJS, true);
 		}
 
-
+		/**
+		 * (non-PHPdoc)
+		 * @see QAutocompleteGen::__set()
+		 */
 		public function __set($strName, $mixValue) {
 			switch ($strName) {
 				case 'DataSource':
@@ -305,7 +247,7 @@
 							}
 						}
 						if ($this->MultipleValueDelimiter) {
-							$strBody = 'response(jQuery.ui.autocomplete.filter('.JavaScriptHelper::toJsObject($mixValue).', this.element.data("splitterFunc")(this.element.get(0))))';
+							$strBody = 'response(jQuery.ui.autocomplete.filter('.JavaScriptHelper::toJsObject($mixValue).', this.element.data("curTerm")(this.element.get(0))))';
 							$mixValue = new QJsClosure($strBody, array('request', 'response'));
 						}
 						// do parent action too
@@ -317,8 +259,10 @@
 					break;
 
 				case 'MultipleValueDelimiter':
-					// Set this at creation time to initialize the selected id.
-					// This is also set by the javascript above to keep track of subsequent selections made by the user.
+					$a = $this->GetAllActions(QAutocomplete_SourceEvent);
+					if (!empty ($a)) {
+						throw new Exception('Must set MultipleValueDelimiter BEFORE calling SetDataBinder');
+					}				
 					try {
 						$this->strMultipleValueDelimiter = QType::Cast($mixValue, QType::String);
 					} catch (QInvalidCastException $objExc) {
@@ -326,7 +270,16 @@
 						throw $objExc;
 					}
 					break;
-
+									
+				case 'DisplayHtml':
+					try {
+						$this->blnDisplayHtml = QType::Cast($mixValue, QType::Boolean);
+					} catch (QInvalidCastException $objExc) {
+						$objExc->IncrementOffset();
+						throw $objExc;
+					}
+					break;
+					
 				default:
 					try {
 						parent::__set($strName, $mixValue);
@@ -344,7 +297,8 @@
 				case 'SelectedId': return $this->strSelectedId;
 				case 'MustMatch': return $this->blnMustMatch;
 				case 'MultipleValueDelimiter': return $this->strMultipleValueDelimiter;
-
+				case 'DisplayHtml': return $this->blnDisplayHtml;
+				
 				default: 
 					try { 
 						return parent::__get($strName); 

--- a/includes/qcubed/_core/base_controls/QAutocompleteGen.class.php
+++ b/includes/qcubed/_core/base_controls/QAutocompleteGen.class.php
@@ -200,6 +200,7 @@
 	 * 		the built-in <code>$.ui.autocomplete.escapeRegex</code> function. It'll
 	 * 		take a single string argument and escape all regex characters, making the
 	 * 		result safe to pass to <code>new RegExp()</code>.</p></li></ul>
+	 * @package Controls\Base
 	 */
 
 	class QAutocompleteGen extends QTextBox	{

--- a/includes/qcubed/_core/base_controls/QTextBoxBase.class.php
+++ b/includes/qcubed/_core/base_controls/QTextBoxBase.class.php
@@ -9,7 +9,7 @@
 	 * This class will render an HTML Textbox -- which can either be [input type="text"],
 	 * [input type="password"] or [textarea] depending on the TextMode (see below).
 	 *
-	 * @package Controls
+	 * @package Controls\Base
 	 *
 	 * @property integer $Columns is the "cols" html attribute (applicable for MultiLine textboxes)
 	 * @property string $Format

--- a/includes/qcubed/controls/QAutocomplete.class.php
+++ b/includes/qcubed/controls/QAutocomplete.class.php
@@ -1,6 +1,6 @@
 <?php
 	/**
-	 * QAccordion
+	 * Override file for QAutocomplete. Put your autocomplete customizations here.
 	 * 
 	 * Put your customizations of the standard behavior here.
 	 * @package Controls  


### PR DESCRIPTION
Autocomplete's custom javascript was getting quite big, and so every time you had an autocomplete on a page, you would get a lot of repeated javascript. This feature/enhancement does the following:
- moves the majority of autocomplete's javascript to a separate file so it gets included only once,
- adds an example of an autocomplete multi-select
- adds the ability to display html in the popup menu
- fixes some doc errors
