### PR TITLE
Using empty instead of array_key_exists

### DIFF
--- a/includes/qcubed/_core/database/QMySqliDatabase.class.php
+++ b/includes/qcubed/_core/database/QMySqliDatabase.class.php
@@ -492,10 +492,8 @@
 		}
 
 		public function GetColumn($strColumnName, $strColumnType = null) {
-			if (array_key_exists($strColumnName, $this->strColumnArray)) {
+			if (!empty($this->strColumnArray[$strColumnName])) {
 				$strColumnValue = $this->strColumnArray[$strColumnName];
-				if (is_null($strColumnValue))
-					return null;
 
 				switch ($strColumnType) {
 					case QDatabaseFieldType::Bit:


### PR DESCRIPTION
This seemingly small change can result in significant speed improvements. On a large table with many rows, GetColumn can be called thousands of times for one query, and "empty" is much faster than "array_key_exists", on the order of 2 to 1000 times in some cases. See http://stackoverflow.com/questions/6884609/array-key-existskey-array-vs-emptyarraykey for one example of someone who benchmarked this.

I know there is a minor difference between the two calls, in that array_key_exists will return true if an item is in the array, but has a value of null, where !empty will return false, but in the code I am changing here, it wants to return null in this case anyway, so !empty is right both logically and speed-wise.
