### PR TITLE
Cannot 'Explain' an update statement, at least, not in MySQL

### DIFF
--- a/assets/_core/php/profile.php
+++ b/assets/_core/php/profile.php
@@ -20,6 +20,10 @@
 		if (substr_count($strOriginalQuery, "AUTOCOMMIT=1") > 0) {
 			return null; 
 		}
+		if (substr_count($strOriginalQuery, "UPDATE") > 0) {
+			return null; // can't explain update statements
+		}
+		
 		$result = "";
 		
 		$objDb = QApplication::$Database[$intDatabaseIndex];


### PR DESCRIPTION
This statement was causing profiling to crash and not complete. MySQL does not support profiling UPDATEs. Can we pull this out, or do we need to figure out how to make this database specific?
