### PR TITLE
Fixing problem with multiple windows.

### DIFF
--- a/includes/qcubed/_core/qform_state_handlers/QSessionFormStateHandler.class.php
+++ b/includes/qcubed/_core/qform_state_handlers/QSessionFormStateHandler.class.php
@@ -32,8 +32,16 @@
 			$_SESSION['qform_' . $intStateIndex] = $strFormState;
 			
 			// Garbage collect
-			if (isset($_POST['Qform__FormState']) && is_numeric($_POST['Qform__FormState'])) {
-			 	unset ($_SESSION['qform_' . $_POST['Qform__FormState']]);
+			
+			if (isset($_POST['Qform__FormState'])) {
+				$strPostDataState = $_POST['Qform__FormState'];
+				if (!is_null(QForm::$EncryptionKey)) {
+					$objCrypto = new QCryptography(QForm::$EncryptionKey, true);
+					$strPostDataState = $objCrypto->Decrypt($strPostDataState);
+				}
+				if (isset($_SESSION['qform_' . $strPostDataState])) {
+					unset ($_SESSION['qform_' . $strPostDataState]);
+				}
 			 }
 
 			// Return StateIndex


### PR DESCRIPTION
If you have two QCubed windows open, you could clobber a formstate, and get the dreaded PHP_Incomplete_Cast error. The scenario is this:

1) Form1 pops up Form2 with an ajax call. formstate_1 is created for Form1, and formstate_2 is created for Form2.
2) Form1 does an ajax call, which sets blnBackupButton to false. The session remembers that the last formstate created was formstate_2. It thinks it does not have to increment the formstate number because blnBackupButton is false, so it creates formstate_2 for Form1.
3) Form2 tries to do an ajax call, and tries to unserialize formstate_2, because that is what is saved in the form. This then crashes, because formstate_2 now contains Form1, and not Form2.

The other formstate handlers do not appear to try to reuse formstate ids, so they are fine. This fix will result in a more rapid increase in the size of the session, so I added some garbage collection to slow that down.
