### PR TITLE
A new attempt at bugfix for session formstate handler

### DIFF
--- a/includes/qcubed/_core/base_controls/QFormBase.class.php
+++ b/includes/qcubed/_core/base_controls/QFormBase.class.php
@@ -168,7 +168,7 @@
 
 			// Ensure strFormId is a subclass of QForm
 			if (!($objClass instanceof QForm))
-				throw new QCallerException('Object is not a subclass of QForm (note, it can NOT be a subclass of QFormBase): ' . $strFormId);
+				throw new QCallerException('Object must be a subclass of QForm: ' . $strFormId);
 
 			// See if we can get a Form Class out of PostData
 			$objClass = null;			
@@ -180,7 +180,9 @@
 					$objClass = QForm::Unserialize($strPostDataState);
 
 				// If there is no QForm Class, then we have an Invalid Form State
-				if (!$objClass) throw new QInvalidFormStateException($strFormId);
+				if (!$objClass) {
+					self::InvalidFormState();
+				}
 			}
 
 			if ($objClass) {
@@ -346,6 +348,35 @@
 			$objClass->Form_Exit();
 		}
 
+		/**
+		 * An invalid form state was found. 
+		 * We were handed a formstate, but the formstate could not be interpreted. This could be for
+		 * a variety of reasons, and is dependent on the formstate handler. Most likely, the user hit
+		 * the back button past the back button limit of what we remember, or the user lost the session.
+		 * Or, you simply have not set up the form state handler correctly.
+		 * In the past, we threw an exception, but that was not a very user friendly response. 
+		 * The response below resubmits the url without a formstate so that a new one will be created. 
+		 * Override if you want a different response.
+		 */
+		public static function InvalidFormState() {
+			ob_clean();
+			if (isset($_POST['Qform__FormCallType']) &&  $_POST['Qform__FormCallType'] == QCallType::Ajax) {
+				// AJAX-based Response
+
+				// Response is in XML Format
+				header('Content-Type: text/xml');
+
+				// Use javascript to reload
+				_p('<?xml version="1.0"?><response><controls/><commands><command>window.location.reload(true);</command></commands></response>', false);
+
+			} else {
+				header('Location: '. QApplication::$RequestUri);
+			}
+
+			// End the Response Script
+			exit();	
+		}
+		
 		public function CallDataBinder($strMethodName, QPaginatedControl $objPaginatedControl, $objParentControl = null) {
 			try {
 				if ($objParentControl)

--- a/includes/qcubed/_core/qform_state_handlers/QSessionFormStateHandler.class.php
+++ b/includes/qcubed/_core/qform_state_handlers/QSessionFormStateHandler.class.php
@@ -1,56 +1,86 @@
 <?php
 	/**
-	 * Simple Session-based FormState handler.  Uses PHP Sessions so it's very straightforward
-	 * and simple, utilizing the session handling and cleanup functionality in PHP, itself.
+	 * Session-based FormState handler.  Uses PHP Sessions to store the form state.
 	 * 
-	 * The downside is that for long running sessions, each individual session file can get
-	 * very, very large, storing all hte various formstate data.  Eventually (if individual
-	 * session files > 10, 15 MB), you can theoretically observe a geometrical
-	 * degradation of performance.
+	 * Stores the variables in the following format:
+	 * $_SESSION['qformstate'][form_uniquid][state#]
+	 *   where the form_uniquid is a unique id that sticks with the window that the
+	 *   form is on, and state# is the formstate associated with that window. Multiple
+	 *   formstates need to be saved to support the browser back button.
 	 * 
 	 * If requested by QForm, the index will be encrypted.
+	 * 
+	 * This incorporates a system of garbage collection that will allow for at most
+	 * 
 	 *
 	 */
 	class QSessionFormStateHandler extends QBaseClass {
+		
+		public static $BackButtonMax = 20; // maximum number of back button states we remember
+		
 		public static function Save($strFormState, $blnBackButtonFlag) {
 			// Compress (if available)
 			if (function_exists('gzcompress'))
 				$strFormState = gzcompress($strFormState, 9);
 				
-			// Setup CurrentStateIndex (if none yet exists)
-			if (!array_key_exists('qform_current_state_index', $_SESSION))
-				$_SESSION['qform_current_state_index'] = 0;
-			
-			// We must always increment the state index, because we may have multiple windows open 
-			$_SESSION['qform_current_state_index'] = $_SESSION['qform_current_state_index'] + 1;
-			$intStateIndex = $_SESSION['qform_current_state_index'];
-
-			// Save THIS formstate
-			// NOTE: if gzcompress is used, we are saving the *BINARY* data stream of the compressed formstate
-			// In theory, this SHOULD work.  But if there is a webserver/os/php version that doesn't like
-			// binary session streams, you can first base64_encode before saving to session (see note below).
-			$_SESSION['qform_' . $intStateIndex] = $strFormState;
-			
-			// Garbage collect
-			
-			if (isset($_POST['Qform__FormState'])) {
-				$strPostDataState = $_POST['Qform__FormState'];
+			if (empty($_POST['Qform__FormState'])) {
+				// no prior form state, so create a new one.
+				$strFormInstance = uniqid();
+				$intFormStateIndex = 1;
+			} else {
+				$strPriorState = $_POST['Qform__FormState'];
+				
 				if (!is_null(QForm::$EncryptionKey)) {
+					// Use QCryptography to Decrypt
 					$objCrypto = new QCryptography(QForm::$EncryptionKey, true);
-					$strPostDataState = $objCrypto->Decrypt($strPostDataState);
+					$strPriorState = $objCrypto->Decrypt($strPriorState);
 				}
-				if (isset($_SESSION['qform_' . $strPostDataState])) {
-					unset ($_SESSION['qform_' . $strPostDataState]);
+				
+				$a = explode ('_', $strPriorState);
+				if (count ($a) == 2 && 
+						is_numeric ($a[1]) &&
+						!empty($_SESSION['qformstate'][$a[0]]['index'])) {
+					$strFormInstance = $a[0];
+					$intFormStateIndex = $_SESSION['qformstate'][$a[0]]['index'];
+					if ($blnBackButtonFlag) { // can we reuse current state info?
+						$intFormStateIndex ++; // nope
+						
+						// try to garbage collect
+						if (count($_SESSION['qformstate'][$a[0]]) > self::$BackButtonMax) {
+							foreach ($_SESSION['qformstate'][$a[0]] as $key=>$val) {
+								if (is_numeric($key) && $key < $_SESSION['qformstate'][$a[0]]['index'] - self::$BackButtonMax) {
+									unset ($_SESSION['qformstate'][$a[0]][$key]);
+								}
+							}
+						}
+					}
+				} else {
+					// couldn't find old session variables, so create new one
+					$strFormInstance = uniqid();
+					$intFormStateIndex = 1;
 				}
-			 }
-
+			}
+				
+			// Setup current state variable
+			if (empty($_SESSION['qformstate'])) {
+				$_SESSION['qformstate'] = array();
+			} 
+			if (empty($_SESSION['qformstate'][$strFormInstance])) {
+				$_SESSION['qformstate'][$strFormInstance] = array();
+			} 
+			
+			$_SESSION['qformstate'][$strFormInstance]['index'] = $intFormStateIndex;
+			$_SESSION['qformstate'][$strFormInstance][$intFormStateIndex] = $strFormState;
+			
+			$strPostDataState = $strFormInstance . '_' . $intFormStateIndex;
+			
 			// Return StateIndex
 			if (!is_null(QForm::$EncryptionKey)) {
 				// Use QCryptography to Encrypt
 				$objCrypto = new QCryptography(QForm::$EncryptionKey, true);
-				return $objCrypto->Encrypt($intStateIndex);
+				return $objCrypto->Encrypt($strPostDataState);
 			} else
-				return $intStateIndex;
+				return $strPostDataState;
 		}
 
 		public static function Load($strPostDataState) {
@@ -58,24 +88,27 @@
 			if (!is_null(QForm::$EncryptionKey)) {
 				// Use QCryptography to Decrypt
 				$objCrypto = new QCryptography(QForm::$EncryptionKey, true);
-				$intStateIndex = $objCrypto->Decrypt($strPostDataState);
-			} else
-				$intStateIndex = $strPostDataState;
-
-			// Pull FormState from Session
+				$strPostDataState = $objCrypto->Decrypt($strPostDataState);
+			}
+		
+			$a = explode ('_', $strPostDataState);
+			if (count ($a) == 2 && 
+					is_numeric ($a[1]) &&
+					!empty($_SESSION['qformstate'][$a[0]][$a[1]])) {
+				$strSerializedForm = $_SESSION['qformstate'][$a[0]][$a[1]];
+			} else {
+				return null;
+			}
+			
+			// Uncompress (if available)
 			// NOTE: if gzcompress is used, we are restoring the *BINARY* data stream of the compressed formstate
 			// In theory, this SHOULD work.  But if there is a webserver/os/php version that doesn't like
 			// binary session streams, you can first base64_decode before restoring from session (see note above).
-			if (array_key_exists('qform_' . $intStateIndex, $_SESSION)) {
-				$strSerializedForm = $_SESSION['qform_' . $intStateIndex];
+			if (function_exists('gzcompress')) {
+				$strSerializedForm = gzuncompress($strSerializedForm);
+			}
 
-				// Uncompress (if available)
-				if (function_exists('gzcompress'))
-					$strSerializedForm = gzuncompress($strSerializedForm);
-
-				return $strSerializedForm;
-			} else
-				return null;
+			return $strSerializedForm;
 		}
 	}
 ?>


### PR DESCRIPTION
I tried a different approach. This one does the following:
- Fixes the previous bug where using multiple windows could cause a situation where a formstate for one window gets deleted by another window, resulting in the dreaded exception thrown. It does this by creating a unique id for each window requesting a form state so that they will not collide.
- Implements a reasonable garbage collection strategy so that the session formstate is actually a usable formstate mechanism and much less likely to get so big that it slows down the system.
- Gets rid of the exception for a lost formstate, and instead just reloads the current page, which is a much better user experience. An excpetion for a lost formstate is not correct, since a lost formstate is a rare, but expected thing to occur (user could backup past our garbage collection scheme, or the session might expire).
