### PR TITLE
Fixing ajax queue to not queue the formstate, in case it changes

### DIFF
--- a/assets/_core/js/jquery/jquery.ajaxq-0.0.1.js
+++ b/assets/_core/js/jquery/jquery.ajaxq-0.0.1.js
@@ -11,6 +11,9 @@
  * http://code.google.com/p/jquery-ajaxq/
  */
 
+/**
+ * Note: this file has been modified from the original found above.
+ */
 jQuery.ajaxq = function (queue, options)
 {
 	// Initialize storage for request queues if it's not initialized yet
@@ -39,16 +42,25 @@ jQuery.ajaxq = function (queue, options)
 			
 			// Run the original callback
 			if (originalCompleteCallback) originalCompleteCallback (request, status);
+			
+			
 
 			// Run the next request from the queue
-			if (document.ajaxq.q[queue].length > 0) document.ajaxq.r = jQuery.ajax (document.ajaxq.q[queue][0]);
+			if (document.ajaxq.q[queue].length > 0) {
+				var options2 = document.ajaxq.q[queue][0];
+				if (options2.fnInit) options2.fnInit (options2);	// last minute changes before the event is fired
+				document.ajaxq.r = jQuery.ajax (options2);
+			}
 		};
 
 		// Enqueue the request
 		document.ajaxq.q[queue].push (options);
 
 		// Also, if no request is currently running, start it
-		if (document.ajaxq.q[queue].length == 1) document.ajaxq.r = jQuery.ajax (options);
+		if (document.ajaxq.q[queue].length == 1) {
+			if (options.fnInit) options.fnInit (options);	// last minute changes before the event is fired
+			document.ajaxq.r = jQuery.ajax (options);
+		}
 	}
 	else // No request settings are given, stop current request and clear the queue
 	{
@@ -60,4 +72,4 @@ jQuery.ajaxq = function (queue, options)
 
 		document.ajaxq.q[queue] = [];
 	}
-}
+};

--- a/assets/_core/php/qcubed_unit_tests.php
+++ b/assets/_core/php/qcubed_unit_tests.php
@@ -15,7 +15,7 @@ require(dirname(__FILE__).'/../../../qcubed.inc.php');
 restore_error_handler();
 
 require_once(__QCUBED_CORE__ . '/tests/qcubed-unit/QUnitTestCaseBase.php');
-
+require_once(__QCUBED_CORE__ . '/tests/qcubed-unit/QTestControl.class.php');
 
 class QHtmlReporter extends HtmlReporter {
 	function paintMethodStart($test_name) {
@@ -46,11 +46,36 @@ class QHtmlReporter extends HtmlReporter {
 }
 
 class QTestForm extends QForm {
+	public $ctlTest;
+	public $pnlOutput;
 
 	protected function Form_Create() {
+		$this->ctlTest = new QTestControl($this);
+		$this->pnlOutput = new QPanel($this, 'outputPanel');
+		
+		$t1 = new QJsTimer($this, 200, false, true, 'timer1');
+		$t1->AddAction(new QTimerExpiredEvent(), new QAjaxAction ('preTest'));
+		$t2 = new QJsTimer($this, 201, false, true, 'timer2');
+		$t2->AddAction(new QTimerExpiredEvent(), new QAjaxAction ('preTest2'));
+		$t3 = new QJsTimer($this, 400, false, true, 'timer3');
+		$t3->AddAction(new QTimerExpiredEvent(), new QServerAction ('runTests'));
+	}
+	
+	public function preTest() {
+		$this->ctlTest->savedValue1 = 2;	// for test in QControlBaseTests
+	}
+	
+	public function preTest2() {
+		$this->ctlTest->savedValue2 = $this->ctlTest->savedValue1;	// for test in QControlBaseTests
+	}
+	
+	
+	public function runTests() {
+		
 		$filesToSkip = array(
 			"QUnitTestCaseBase.php"
 			, "QTestForm.tpl.php"
+			, "QTestControl.class.php"
 		);
 
 		$arrFiles = QFolder::listFilesInFolder(__QCUBED_CORE__ . '/tests/qcubed-unit/');

--- a/includes/qcubed/_core/tests/_README.txt
+++ b/includes/qcubed/_core/tests/_README.txt
@@ -1,0 +1,7 @@
+To create a new unit test suite:
+
+1) Create a php file in qcubed-unit.
+2) In the php file, create a subclass of QUnitTestCaseBase
+3) Create tests that are public methods and that start with the word "test".
+
+All methods that start with "test" in each of the files will be run by the tester.

--- a/includes/qcubed/_core/tests/qcubed-unit/QControlBaseTests.php
+++ b/includes/qcubed/_core/tests/qcubed-unit/QControlBaseTests.php
@@ -1,22 +1,5 @@
 <?php
 
-class QTestControl extends QControl {
-	protected function GetControlHtml() {
-		return "";
-	}
-
-	public function ParsePostData() {
-		
-	}
-
-	public function Validate() {
-		return true;
-	}
-	
-	public function GetWrapperStyleAttributes($blnIsBlockElement=false) {
-		return parent::GetWrapperStyleAttributes($blnIsBlockElement);
-	}
-}
 /**
  * 
  * @package Tests
@@ -36,6 +19,7 @@ class QControlBaseTests extends QUnitTestCaseBase {
 	public function __construct($objForm) {
 		parent::__construct($objForm);
 		$this->frmTest = $objForm;
+		$this->ctlTest = $objForm->ctlTest;
 	}
 
 	protected function helpTest($objTestDataArray, $objProperiesArray, $strGetStyleMethod = "GetWrapperStyleAttributes") {
@@ -58,9 +42,7 @@ class QControlBaseTests extends QUnitTestCaseBase {
 		}
 	}
 
-	public function testCss() {
-		$this->ctlTest = new QTestControl($this->frmTest);
-		
+	public function testCss() {		
 		$objCaseArray = array( 
 			array(
 				"Value" => "0", "Expected" => "0;", "Msg" => "String zero renders with no 'px'"
@@ -144,5 +126,13 @@ class QControlBaseTests extends QUnitTestCaseBase {
 		}
 
 	}
+	
+	public function testAjaxChangeFormState() {
+		if (!QApplication::$CliMode) {
+			$this->assertTrue ($this->ctlTest->savedValue1 == 2, "Actions can change state for later queued actions.");
+			$this->assertTrue ($this->ctlTest->savedValue2 == 2, "Actions can change state for later queued actions.");
+		}
+	}
+	
 }
 ?>

--- a/includes/qcubed/_core/tests/qcubed-unit/QTestControl.class.php
+++ b/includes/qcubed/_core/tests/qcubed-unit/QTestControl.class.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * This is used by control tests. Must be here so it can be unserialized, since tests are dynamically loaded.
+ */
+
+/*
+ * This is used by control tests. Must be here so it can be unserialized, since tests are dynamically loaded.
+ */
+class QTestControl extends QControl {
+	public $savedValue1 = 1;
+	public $savedValue2 = 0;
+	
+	protected function GetControlHtml() {
+		return "";
+	}
+
+	public function ParsePostData() {
+		
+	}
+
+	public function Validate() {
+		return true;
+	}
+	
+	public function GetWrapperStyleAttributes($blnIsBlockElement=false) {
+		return parent::GetWrapperStyleAttributes($blnIsBlockElement);
+	}
+}
+
+
+?>

--- a/travis/test.php
+++ b/travis/test.php
@@ -27,6 +27,7 @@ require('travis/qcubed.inc.php');
 restore_error_handler();
 
 require_once(__QCUBED_CORE__ . '/tests/qcubed-unit/QUnitTestCaseBase.php');
+require_once(__QCUBED_CORE__ . '/tests/qcubed-unit/QTestControl.class.php');
 
 
 class QTravisReporter extends TextReporter {
@@ -42,11 +43,15 @@ class QTravisReporter extends TextReporter {
 $rptReporter = null;
 
 class QTestForm extends QForm {
+	public $ctlTest;
 
 	protected function Form_Create() {
+		$this->ctlTest = new QTestControl($this);
+
 		$filesToSkip = array(
 			"QUnitTestCaseBase.php"
 			, "QTestForm.tpl.php"
+			, "QTestControl.class.php"
 		);
 
 		$arrFiles = QFolder::listFilesInFolder(__QCUBED_CORE__ . '/tests/qcubed-unit/');


### PR DESCRIPTION
This fix will help with many random formstate problems, including situations where you get messages that the session has been lost, even though it hasn't, or that you are trying to cast an empty object to a form. This is especially problematic when popping up multiple windows that each have QCubed forms, as the formstates will no longer correspond to even the form object types, causing the dreaded "Trying to cast PHP_Empty_Object to Form.." problem.

The problem shows up primarily when one action triggers multiple events, and the first event changes something in the formstate. The 2nd event will squash the formstate because it had saved it previously, and then you will eventually get an error since the formstate is no longer valid.

I tested this fix with QFormStateHandler and QSessionStateHandler, and seems to work well.

(copied from #180)
