### PR TITLE
An asterix is added for an example title

### DIFF
--- a/assets/_core/php/examples/includes/examples.inc.php
+++ b/assets/_core/php/examples/includes/examples.inc.php
@@ -148,7 +148,7 @@
 			self::AddCoreExampleFile($intIndex, '/advanced_ajax/drop_zone.php Move Handle: Defining Drop Zones');
 			self::AddCoreExampleFile($intIndex, '/advanced_ajax/resize_jquery.php Resizing Block Controls');
 			self::AddCoreExampleFile($intIndex, '/advanced_ajax/dialog_box.php Modal "Dialog Boxes"');
-			self::AddCoreExampleFile($intIndex, '/other_controls/jq_example.php Server-side wrappers for all jQuery UI Controls');
+			self::AddCoreExampleFile($intIndex, '/other_controls/jq_example.php * Server-side wrappers for all jQuery UI Controls');
 			self::AddCoreExampleFile($intIndex, '/other_controls/js_return_param_example.php Post data back to the server from jQuery UI controls');
 			self::AddCoreExampleFile($intIndex, '/advanced_ajax/jquery_effects.php JQuery Effects');
 			


### PR DESCRIPTION
I've forgot this patch when the 2.2.1 release was prepared
