### PR TITLE
The checkbox column example is fixed

### DIFF
--- a/assets/_core/php/examples/dynamic/qcheckboxcolumn.php
+++ b/assets/_core/php/examples/dynamic/qcheckboxcolumn.php
@@ -164,12 +164,12 @@
 				QQ::Virtual('assn_item', 
 					QQ::SubSql(
 						'select 
-							"project_id"
+							project_id
 					 	from 
-					 		"related_project_assn"
+					 		related_project_assn
 					 	where 
-							"child_project_id" = {1} 
-							 and "project_id" = 1', 
+							child_project_id = {1} 
+							 and project_id = 1', 
 							QQN::Project()->Id)
 				)
 			);


### PR DESCRIPTION
I've forgot this patch when the 2.2.1 release was prepared
