### PR TITLE
installation wizard error in my windows local wamp installation

### DIFF
--- a/assets/_core/php/_devtools/installer/step_2.php
+++ b/assets/_core/php/_devtools/installer/step_2.php
@@ -67,6 +67,9 @@
 	// Installation directory seems to be under document root.
 	// Try to figure out the subdirectory
 	$strSubDirectory = substr($strInstallationDir, (strlen($strServerDocumentRoot)), (strlen($strInstallationDir) - 1));
+	if (DIRECTORY_SEPARATOR !== mb_substr($strSubDirectory, 0, 1)) {
+		$strSubDirectory = DIRECTORY_SEPARATOR . $strSubDirectory;
+	}
 
 	// Make sure the installation directory supplied exists
 	if(!is_dir($strInstallationDir)) {

--- a/includes/qcubed/_core/error.inc.php
+++ b/includes/qcubed/_core/error.inc.php
@@ -53,7 +53,12 @@
 		}
 
 		// Call to display the Error Page (as defined in configuration.inc.php)
-		require(__DOCROOT__ . ERROR_PAGE_PATH);
+		if (defined('ERROR_PAGE_PATH')) {
+			require(__DOCROOT__ . ERROR_PAGE_PATH);
+		} else {
+			// Error in installer or similar - ERROR_PAGE_PATH constant is not defined yet.
+			echo "error: errno: ". $__exc_errno . "<br/>" . $__exc_errstr . "<br/>" . $__exc_errfile . ":" . $__exc_errline . "<br/>" . $__exc_errcontext ; 
+		}
 		exit();
 	}
 
@@ -151,7 +156,12 @@
 		}
 
 		// Call to display the Error Page (as defined in configuration.inc.php)
-		require(__DOCROOT__ . ERROR_PAGE_PATH);
+		if (defined('ERROR_PAGE_PATH')) {
+			require(__DOCROOT__ . ERROR_PAGE_PATH);
+		} else {
+			// Error in installer or similar - ERROR_PAGE_PATH constant is not defined yet.
+			echo "error: errno: ". $__exc_errno . "<br/>" . $__exc_errstr . "<br/>" . $__exc_errfile . ":" . $__exc_errline . "<br/>" . $__exc_errcontext ; 
+		}
 		exit();
 	}
 ?>

--- a/includes/qcubed/_core/framework/QApplicationBase.class.php
+++ b/includes/qcubed/_core/framework/QApplicationBase.class.php
@@ -129,7 +129,7 @@
 		 *
 		 * @var string EncodingType
 		 */
-		public static $EncodingType = __QAPPLICATION_ENCODING_TYPE__;
+		public static $EncodingType = "UTF-8";
 
 		/**
 		 * An array of Database objects, as initialized by QApplication::InitializeDatabaseConnections()
@@ -218,6 +218,8 @@
 		 * @return void
 		 */
 		public static function Initialize() {
+			self::$EncodingType = defined('__QAPPLICATION_ENCODING_TYPE__') ? __QAPPLICATION_ENCODING_TYPE__ : self::$EncodingType;
+
 			$strCacheProviderClass = 'QCacheProviderNoCache';
 			if (defined('CACHE_PROVIDER_CLASS')) {
 				$strCacheProviderClass = CACHE_PROVIDER_CLASS;


### PR DESCRIPTION
The issue #255 is addressed here:
1. error page now works with no configuration.inc.php file at all
2. QApplicationBase works with no configuration.inc.php file at all
3. The `__SUBDIRECTORY__` constant formed by installer is always created with leading '/' character
