### PR TITLE
The "Introduction to QSoapService" example is broken

### DIFF
--- a/includes/qcubed/_core/framework/QSoapService.class.php
+++ b/includes/qcubed/_core/framework/QSoapService.class.php
@@ -40,7 +40,7 @@
 			}
 
 			$objReflection = new ReflectionMethod($this->strType, 'AlterSoapComplexTypeArray');
-			$objReflection->invoke(null, $strComplexTypesArray, false);
+			$objReflection->invoke(null, &$strComplexTypesArray, false);
 			return $strToReturn;
 		}
 


### PR DESCRIPTION
It seems that in a PHP 5.3 the '&' operator behavior has changed.
