### PR TITLE
Missing QDateTime object for display only object

### DIFF
--- a/includes/qcubed/_core/codegen/templates/db_orm/meta_control/variable_declarations.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_orm/meta_control/variable_declarations.tpl.php
@@ -40,6 +40,14 @@
 		 * @access protected
 		 */
 		protected $<?php echo $objCodeGen->FormLabelVariableNameForColumn($objColumn);  ?>;
+		
+<?php if ($objColumn->VariableType == 'QDateTime') {?>
+		/**
+		 * @var str<?php echo $objColumn->PropertyName  ?>DateTimeFormat
+		 * @access protected
+		 */
+		protected $str<?php echo $objColumn->PropertyName  ?>DateTimeFormat;
+<?php } ?>
 <?php } ?>
 <?php } ?>
 


### PR DESCRIPTION
Code gen was not generating the string version of a QDateTime object for the label version of the object.
