### PR TITLE
Fix app_includes bug with QApplication class for certain cases

### DIFF
--- a/includes/configuration/prepend.inc.php
+++ b/includes/configuration/prepend.inc.php
@@ -34,7 +34,6 @@
 		//////////////////////////////
 		require(__QCUBED_CORE__ . '/framework/DisableMagicQuotes.inc.php');
 		require(__QCUBED_CORE__ . '/qcubed.inc.php');
-		require(__APP_INCLUDES__ . '/app_includes.inc.php');
 
 		///////////////////////////////
 		// Define the Application Class
@@ -145,5 +144,6 @@
 			// QApplication::$LanguageCode = 'en';
 			// QI18n::Initialize();
 		}
+		require(__APP_INCLUDES__ . '/app_includes.inc.php');
 	}
 ?>


### PR DESCRIPTION
If you have some code which is initialized via app_includes.inc.php and that code uses any variable/method of QApplication then the same would fail because when app_includes.inc.php is included, QCubed is not completely finished bootstrapping. This change ensures that all code initialized via app_includes can use the QApplication class. 
