### PR TITLE
Fixing warning with php 5.4 and datarepeater with template

### DIFF
--- a/includes/qcubed/_core/base_controls/QFormBase.class.php
+++ b/includes/qcubed/_core/base_controls/QFormBase.class.php
@@ -948,7 +948,9 @@
 				QApplication::$ProcessOutput = false;
 				// Store the Output Buffer locally
 				$strAlreadyRendered = ob_get_contents();
-				ob_clean();
+                if ($strAlreadyRendered) {
+                    ob_clean();
+                }
 
 				// Evaluate the new template
 				ob_start('__QForm_EvaluateTemplate_ObHandler');
@@ -957,7 +959,9 @@
 				ob_end_clean();
 
 				// Restore the output buffer and return evaluated template
-				print($strAlreadyRendered);
+                if ($strAlreadyRendered) {
+                    print($strAlreadyRendered);
+                }
 				QApplication::$ProcessOutput = true;
 
 				return $strTemplateEvaluated;


### PR DESCRIPTION
If the first thing on a page is something that use EvalTemplate, a new PHP 5.4 warning pops up saying that ob_clean failed because there was no buffer. Just making sure that there was a buffer before trying to clean.
