### PR TITLE
Catching and reporting fatal errors.

### DIFF
--- a/includes/configuration/prepend.inc.php
+++ b/includes/configuration/prepend.inc.php
@@ -102,6 +102,7 @@
 		if (array_key_exists('SERVER_PROTOCOL', $_SERVER)) {
 			set_error_handler('QcodoHandleError', error_reporting());
 			set_exception_handler('QcodoHandleException');
+			register_shutdown_function('QCubedShutdown');
 		}
 
 

--- a/includes/qcubed/_core/error.inc.php
+++ b/includes/qcubed/_core/error.inc.php
@@ -164,4 +164,21 @@
 		}
 		exit();
 	}
+
+	/**
+	 * Some errors are not caught by a php custom error handler, which can cause the system to silently fail.
+	 * This shutdown function will catch those errors.
+	 */
+	function QCubedShutdown() {
+		if ($error = error_get_last()){
+			QCodoHandleError (
+				$error['type'],
+				$error['message'],
+				$error['file'],
+				$error['line'],
+				''
+			);
+		}
+	}
+
 ?>


### PR DESCRIPTION
Fixes problem where fatal errors silently fail. Examples:
- Calling a method that doesn't exist.
- Calling a method that is protected or private from a public context.

It now will put up the standard QCubed dialog.
