### PR TITLE
Improved browser detection, including detecting mobile browsers

### DIFF
--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -957,7 +957,7 @@
 				$strToReturn .= sprintf("overflow:%s;", $this->strOverflow);
 
 			if (!is_null($this->intOpacity)) {
-				if (QApplication::IsBrowser(QBrowserType::InternetExplorer))
+				if (QApplication::IsBrowser(QBrowserType::InternetExplorer) && QApplication::$BrowserVersion < 9)
 					$strToReturn .= sprintf('filter:alpha(opacity=%s);', $this->intOpacity);
 				else
 					$strToReturn .= sprintf('opacity:%s;', $this->intOpacity / 100.0);

--- a/install/project/includes/controls/QJsTimer.class.php
+++ b/install/project/includes/controls/QJsTimer.class.php
@@ -243,7 +243,7 @@
 				$strToReturn .= ' ' . $objAction->RenderScript($this);
 			}
 			if ($this->ActionsMustTerminate) {
-				if (QApplication::IsBrowser(QBrowserType::InternetExplorer_6_0)) {
+				if (QApplication::IsBrowser(QBrowserType::InternetExplorer) && QApplication::$BrowserVersion < 7) {
 					$strToReturn .= ' qc.terminateEvent(event);';
 				} else {
 					$strToReturn .= ' return false;';


### PR DESCRIPTION
The current way of detecting browsers and versions was simply unsupportable. We ran out of bits. I separated out the browser name detection from the browser version number detection.

Generally, we shouldn't be doing browser detection to determine features. However, users don't know about features, they only know about browsers and version numbers. So, if we need to detect whether a particular browser is supported by our application, we can do it now, and it should last into the foreseeable future.

Also adds detection for a mobile browser, in case you want to serve up a different set of pages for mobile browsers.
