### PR TITLE
Fixes the annoyingly small error dialog.

### DIFF
--- a/assets/_core/js/qcubed.js
+++ b/assets/_core/js/qcubed.js
@@ -259,8 +259,7 @@ $j.ajaxSync.data = [];
 									.html(result)
 									.dialog({
 										modal: true,
-										height: 200,
-										width: 400,
+										width: 'auto',
 										autoOpen: true,
 										title: 'An Error Occurred',
 										buttons: {


### PR DESCRIPTION
The popup that displays an qcubed ajax error is annoyingly small. Setting the popup to have a width of auto fixes this.
