### PR TITLE
Fix QType Cast Double value to Integer value bug.

### DIFF
--- a/includes/qcubed/_core/framework/QType.class.php
+++ b/includes/qcubed/_core/framework/QType.class.php
@@ -146,8 +146,8 @@
 						return $intItem;
 					
 					// if casting changed the value, but we have a valid integer, return with a string cast
-					if (preg_match('/^-?\d+$/',$mixItem) === 1)
-						return (string)$mixItem;
+					if (preg_match('/^-?\d+(\.\d+)?$/',$mixItem) === 1)
+						return (string)(int)$mixItem;
 					
 					// any other scenarios is an invalid cast
 					throw new QInvalidCastException(sprintf('Unable to cast %s value to %s: %s', $strOriginalType, $strNewType, $mixItem));


### PR DESCRIPTION
PHP Allows us to cast double values to integers quite easily. Assuming the double value to be `4.4519452160494`, the following code will cast the value to 4:

```
$dblValue = 4.4519452160494;
$intValue = (int)$dblValue;
```

However, when we do:

```
$dblValue = 4.4519452160494;
$intValue = QType::Cast($dblValue, QType::Integer);
```

We get an error. This is because we are checking for only 'digits' when the conversion from old format to new and back does not yield the same result. The current change tries to fix this.
