### PR TITLE
Setting QListControl value to a string version of a number does not work when the objects are integers internally.

### DIFF
--- a/includes/qcubed/_core/base_controls/QListControl.class.php
+++ b/includes/qcubed/_core/base_controls/QListControl.class.php
@@ -350,10 +350,25 @@
 
 				case "SelectedValue":
 					foreach ($this->objItemsArray as $objItem)
-						if ($objItem->Value == $mixValue)
+						if (!$mixValue) {
+							if ($mixValue === null || $mixValue === '') {
+								if ($objItem->Value === null || $objItem->Value === '') {
+									$objItem->Selected = true;
+								} else {
+									$objItem->Selected = false;
+								}
+							} else {
+								if ($objItem->Value === null || $objItem->Value === '') {
+									$objItem->Selected = false;
+								} else {
+									$objItem->Selected = true;
+								}
+							}
+						} elseif ($objItem->Value == $mixValue) {
 							$objItem->Selected = true;
-						else
+						} else {
 							$objItem->Selected = false;
+						}
 					return $mixValue;
 					break;
 
@@ -379,21 +394,35 @@
 
 				case "SelectedValues":
 					try {
-						$mixValue = QType::Cast($mixValue, QType::ArrayType);
+						$mixValues = QType::Cast($mixValue, QType::ArrayType);
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
 						throw $objExc;
 					}
 					foreach ($this->objItemsArray as $objItem) {
 						$objItem->Selected = false;
-						foreach ($mixValue as $mixName) {
-							if ($objItem->Value == $mixName) {
+						$mixCurVal = $objItem->Value;
+						foreach ($mixValues as $mixValue) {
+							if (!$mixValue) {
+								if ($mixValue === null || $mixValue === '') {
+									if ($mixCurVal === null || $mixCurVal === '') {
+										$objItem->Selected = true;
+										break;
+									}
+								} else {
+									if (!($mixCurVal === null || $mixCurVal === '')) {
+										$objItem->Selected = true;
+										break;
+									}
+								}
+							}
+							elseif ($mixCurVal == $mixValue) {
 								$objItem->Selected = true;
 								break;
 							}
 						}
 					}
-					return $mixValue;
+					return $mixValues;
 					break;
 
 				default:


### PR DESCRIPTION
We recently did a fix to try to differentiate between null, and zero, but it went too far and differentiated between string versions of numbers and int versions of numbers. This is a problem when the values come in as GET values, since those are strings. This should fix that. It equates null with an empty string, and 0, '0' and false are considered equal, and fixes the other problem.
