### PR TITLE
typo bug fix for the label of many-to-many type control

### DIFF
--- a/includes/qcubed/_core/codegen/templates/db_orm/meta_control/control_create_manytomany_type.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_orm/meta_control/control_create_manytomany_type.tpl.php
@@ -22,7 +22,7 @@
 		 */
 		public function <?php echo $strLabelId  ?>_Create($strControlId = null) {
 			$this-><?php echo $strLabelId  ?> = new QLabel($this->objParentObject, $strControlId);
-			$this-><?php echo $strControlId  ?>->Name = QApplication::Translate('<?php echo QConvertNotation::WordsFromCamelCase($objManyToManyReference->ObjectDescriptionPlural)  ?>');
+			$this-><?php echo $strLabelId  ?>->Name = QApplication::Translate('<?php echo QConvertNotation::WordsFromCamelCase($objManyToManyReference->ObjectDescriptionPlural)  ?>');
 			
 			$aSelection = $this-><?php echo $strObjectName?>->Get<?php echo $objManyToManyReference->ObjectDescription?>Array();
 			$this-><?php echo $strLabelId  ?>->Text = implode($this->str<?php echo $objManyToManyReference->ObjectDescription;  ?>Glue, $aSelection);


### PR DESCRIPTION
This fixes a typo in the MetaControlGen template for the many-to-many type control, that results in a NPE
