### PR TITLE
QEmailMessage added support for reply-to

### DIFF
--- a/includes/qcubed/_core/framework/QEmailServer.class.php
+++ b/includes/qcubed/_core/framework/QEmailServer.class.php
@@ -304,7 +304,13 @@
 			fwrite($objResource, sprintf("Date: %s\r\n", QDateTime::NowToString(QDateTime::FormatRfc5322)));
 			fwrite($objResource, sprintf("To: %s\r\n", $objMessage->To));
 			fwrite($objResource, sprintf("From: %s\r\n", $objMessage->From));
-
+			if($objMessage->ReplyTo) {
+				fwrite($objResource, sprintf("Reply-To: %s\r\n", $objMessage->ReplyTo));
+			}
+			if($objMessage->Sender) {
+				fwrite($objResource, sprintf("Sender: %s\r\n", $objMessage->Sender));
+			}
+			
 			// Setup Encoding Type (use QEmailServer if specified, otherwise default to QApplication's)
 			if (!($strEncodingType = QEmailServer::$EncodingType))
 				$strEncodingType = QApplication::$EncodingType;
@@ -484,8 +490,21 @@
 		}
 	}
 
+	/**
+	 * @property string $From
+	 * @property string $ReplyTo
+	 * @property string $Sender
+	 * @property string $To
+	 * @property string $Cc
+	 * @property string $Bcc
+	 * @property string $Subject
+	 * @property string $Body
+	 * @property string $HtmlBody
+	 */
 	class QEmailMessage extends QBaseClass {
 		protected $strFrom;
+		protected $strReplyTo;
+		protected $strSender;
 		protected $strTo;
 		protected $strSubject;
 		protected $strBody;
@@ -535,8 +554,10 @@
 
 		public function __get($strName) {
 			switch ($strName) {
-				case 'From': return $this->strFrom;
-				case 'To': return $this->strTo;
+				case 'From'		: return $this->strFrom;
+				case 'ReplyTo'		: return $this->strReplyTo;
+				case 'Sender'		: return $this->strSender;
+				case 'To'		: return $this->strTo;
 				case 'Subject': return $this->strSubject;
 				case 'Body': return $this->strBody;
 				case 'HtmlBody': return $this->strHtmlBody;
@@ -561,7 +582,9 @@
 		public function __set($strName, $mixValue) {
 			try {
 				switch ($strName) {
-					case 'From': return ($this->strFrom = QType::Cast($mixValue, QType::String));
+					case 'From'	: return ($this->strFrom = QType::Cast($mixValue, QType::String));
+					case 'ReplyTo'	: return ($this->strReplyTo = QType::Cast($mixValue, QType::String));
+					case 'Sender'	: return ($this->strSender = QType::Cast($mixValue, QType::String));
 					case 'To': return ($this->strTo = QType::Cast($mixValue, QType::String));
 					case 'Subject':
 						$strSubject = trim(QType::Cast($mixValue, QType::String));


### PR DESCRIPTION
If you want to send Email on behalf of your customers and do not want to be flagged as spam, you have to be able to enter the header Reply-To and Sender.
These changes make that possible.
