### PR TITLE
replace the old <template OverwriteFlag=.../> lines in php templates

### DIFF
--- a/includes/qcubed/_core/codegen/QCodeGenBase.class.php
+++ b/includes/qcubed/_core/codegen/QCodeGenBase.class.php
@@ -344,14 +344,39 @@
 			return $blnSuccess;
 		}
 
+		protected function getTemplateSettings($strTemplateFilePath, $strTemplate = null) {
+			if ($strTemplate === null)
+				$strTemplate = file_get_contents($strTemplateFilePath);
+			$strError = 'Template\'s first line must be <template OverwriteFlag="boolean" DocrootFlag="boolean" TargetDirectory="string" DirectorySuffix="string" TargetFileName="string"/>: ' . $strTemplateFilePath;
+			// Parse out the first line (which contains path and overwriting information)
+			$intPosition = strpos($strTemplate, "\n");
+			if ($intPosition === false) {
+				throw new Exception($strError);
+			}
+
+			$strFirstLine = trim(substr($strTemplate, 0, $intPosition));
+
+			$objTemplateXml = null;
+			// Attempt to Parse the First Line as XML
+			try {
+				@$objTemplateXml = new SimpleXMLElement($strFirstLine);
+			} catch (Exception $objExc) {}
+
+			if (is_null($objTemplateXml) || (!($objTemplateXml instanceof SimpleXMLElement)))
+				throw new Exception($strError);
+			return $objTemplateXml;
+		}
+
 		/**
-		 * Enter description here...
+		 * Generates a php code using a template file
 		 *
 		 * @param string $strModuleName
 		 * @param string $strFilename
 		 * @param boolean $blnOverrideFlag whether we are using the _core template, or using a custom one
 		 * @param mixed[] $mixArgumentArray
-		 * @param boolean $blnSave wheather or not to actually perform the save
+		 * @param boolean $blnSave whether or not to actually perform the save
+		 * @throws QCallerException
+		 * @throws Exception
 		 * @return mixed returns the evaluated template or boolean save success.
 		 */
 		public function GenerateFile($strModuleName, $strFilename, $blnOverrideFlag, $mixArgumentArray, $blnSave = true) {
@@ -363,12 +388,10 @@
 
 			// Setup Debug/Exception Message
 			if (QCodeGen::DebugMode) _p("Evaluating $strTemplateFilePath<br/>", false);
-			$strError = 'Template\'s first line must be <template OverwriteFlag="boolean" DocrootFlag="boolean" TargetDirectory="string" DirectorySuffix="string" TargetFileName="string"/>: ' . $strTemplateFilePath;
 
 			// Check to see if the template file exists, and if it does, Load It
 			if (!file_exists($strTemplateFilePath))
 				throw new QCallerException('Template File Not Found: ' . $strTemplateFilePath);
-			$strTemplate = file_get_contents($strTemplateFilePath);
 
 			// Evaluate the Template
 			if (substr($strFilename, strlen($strFilename) - 8) == '.tpl.php')  {
@@ -378,39 +401,28 @@
 						get_include_path();
 				set_include_path ($strSearchPath);
 				if ($strSearchPath != get_include_path()) {
-					throw new QCallerException ('Can\'t override include path. Make sure your apache or server settings allow include paths to be overriden. ' );
+					throw new QCallerException ('Can\'t override include path. Make sure your apache or server settings allow include paths to be overridden. ' );
 				}
-				$strTemplate = $this->EvaluatePHP($strTemplateFilePath, $strModuleName, $mixArgumentArray);
+				$strTemplate = $this->EvaluatePHP($strTemplateFilePath, $strModuleName, $mixArgumentArray, $templateSettings);
 				restore_include_path();
+				if (!isset($templateSettings) || !$templateSettings) {
+					// check if we have old style <template .../> settings
+					$templateSettings = $this->getTemplateSettings($strTemplateFilePath, $strTemplate);
+				}
 			} else {
+				$strTemplate = file_get_contents($strTemplateFilePath);
 				$strTemplate = $this->EvaluateTemplate($strTemplate, $strModuleName, $mixArgumentArray);
+				$templateSettings = $this->getTemplateSettings($strTemplateFilePath, $strTemplate);
 			}
-			
-			// Parse out the first line (which contains path and overwriting information)
-			$intPosition = strpos($strTemplate, "\n");
-			if ($intPosition === false)
-				throw new Exception($strError);
 
-			$strFirstLine = trim(substr($strTemplate, 0, $intPosition));
-			$strTemplate = substr($strTemplate, $intPosition + 1);
-
-			$objTemplateXml = null;
-			// Attempt to Parse the First Line as XML
-			try {
-				@$objTemplateXml = new SimpleXMLElement($strFirstLine);
-			} catch (Exception $objExc) {}
-
-			if (is_null($objTemplateXml) || (!($objTemplateXml instanceof SimpleXMLElement)))
-				throw new Exception($strError);
-
-			$blnOverwriteFlag = QType::Cast($objTemplateXml['OverwriteFlag'], QType::Boolean);
-			$blnDocrootFlag = QType::Cast($objTemplateXml['DocrootFlag'], QType::Boolean);
-			$strTargetDirectory = QType::Cast($objTemplateXml['TargetDirectory'], QType::String);
-			$strDirectorySuffix = QType::Cast($objTemplateXml['DirectorySuffix'], QType::String);
-			$strTargetFileName = QType::Cast($objTemplateXml['TargetFileName'], QType::String);
+			$blnOverwriteFlag = QType::Cast($templateSettings['OverwriteFlag'], QType::Boolean);
+			$blnDocrootFlag = QType::Cast($templateSettings['DocrootFlag'], QType::Boolean);
+			$strTargetDirectory = QType::Cast($templateSettings['TargetDirectory'], QType::String);
+			$strDirectorySuffix = QType::Cast($templateSettings['DirectorySuffix'], QType::String);
+			$strTargetFileName = QType::Cast($templateSettings['TargetFileName'], QType::String);
 
 			if (is_null($blnOverwriteFlag) || is_null($strTargetFileName) || is_null($strTargetDirectory) || is_null($strDirectorySuffix) || is_null($blnDocrootFlag))
-				throw new Exception($strError);
+				throw new Exception('the template settings cannot be null');
 
 			if ($blnSave && $strTargetDirectory) {
 				// Figure out the REAL target directory
@@ -437,13 +449,13 @@
 			}
 
 			// Why Did We Not Save?
-			if ($blnSave)
+			if ($blnSave) {
 				// We WANT to Save, but QCubed Configuration says that this functionality/feature should no longer be generated
 				// By definition, we should return "true"
 				return true;
-			else
-				// Running GenerateFile() specifically asking it not to save -- so return the evaluated template instead
-				return $strTemplate;
+			}
+			// Running GenerateFile() specifically asking it not to save -- so return the evaluated template instead
+			return $strTemplate;
 		}
 
 		protected function setGeneratedFilePermissions($strFilePath) {
@@ -456,11 +468,14 @@
 			}
 		}
 
-		protected function EvaluatePHP($strFilename, $strModuleName, $mixArgumentArray)  {
+		protected function EvaluatePHP($strFilename, $strModuleName, $mixArgumentArray, &$templateSettings = null)  {
 			// Get all the arguments and set them locally
 			if ($mixArgumentArray) foreach ($mixArgumentArray as $strName=>$mixValue) {
 				$$strName = $mixValue;
 			}
+			global $_TEMPLATE_SETTINGS;
+			unset($_TEMPLATE_SETTINGS);
+			$_TEMPLATE_SETTINGS = null;
 
 			// Of course, we also need to locally allow "objCodeGen"
 			$objCodeGen = $this;
@@ -477,6 +492,9 @@
 			include($strFilename);
 			$strTemplate = ob_get_contents();
 			ob_end_clean();
+
+			$templateSettings = $_TEMPLATE_SETTINGS;
+			unset($_TEMPLATE_SETTINGS);
 
 			// Restore the output buffer and return evaluated template
 			print($strAlreadyRendered);

--- a/includes/qcubed/_core/codegen/templates/aggregate_db_orm/class_paths/_main.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/aggregate_db_orm/class_paths/_main.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="true" DocrootFlag="false" DirectorySuffix="" TargetDirectory="<?php echo __MODEL_GEN__  ?>" TargetFileName="_class_paths.inc.php"/>
+<?php
+	/** @var QTable[] $objTableArray */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => true,
+		'DocrootFlag' => false,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __MODEL_GEN__,
+		'TargetFileName' => '_class_paths.inc.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 <?php foreach ($objTableArray as $objTable) { ?>
 	// ClassPaths for the <?php echo $objTable->ClassName  ?> class

--- a/includes/qcubed/_core/codegen/templates/aggregate_db_orm/qqn/_main.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/aggregate_db_orm/qqn/_main.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="true" DocrootFlag="false" DirectorySuffix="" TargetDirectory="<?php echo __MODEL_GEN__  ?>" TargetFileName="QQN.class.php"/>
+<?php
+	/** @var QTable[] $objTableArray */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => true,
+		'DocrootFlag' => false,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __MODEL_GEN__,
+		'TargetFileName' => 'QQN.class.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	class QQN {
 <?php foreach ($objTableArray as $objTable) { ?>

--- a/includes/qcubed/_core/codegen/templates/aggregate_db_type/class_paths/_main.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/aggregate_db_type/class_paths/_main.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="true" DocrootFlag="false" DirectorySuffix="" TargetDirectory="<?php echo __MODEL_GEN__  ?>" TargetFileName="_type_class_paths.inc.php"/>
+<?php
+	/** @var QTable[] $objTableArray */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => true,
+		'DocrootFlag' => false,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __MODEL_GEN__,
+		'TargetFileName' => '_type_class_paths.inc.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 <?php foreach ($objTableArray as $objTable) { ?>
 	// ClassPaths for the <?php echo $objTable->ClassName  ?> type class

--- a/includes/qcubed/_core/codegen/templates/db_orm/class_gen/_main.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_orm/class_gen/_main.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="true" DocrootFlag="false" DirectorySuffix="" TargetDirectory="<?php echo __MODEL_GEN__  ?>" TargetFileName="<?php echo $objTable->ClassName  ?>Gen.class.php"/>
+<?php
+	/** @var QTable $objTable */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => true,
+		'DocrootFlag' => false,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __MODEL_GEN__,
+		'TargetFileName' => $objTable->ClassName . 'Gen.class.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	/**
 	 * The abstract <?php echo $objTable->ClassName  ?>Gen class defined here is

--- a/includes/qcubed/_core/codegen/templates/db_orm/class_subclass/_main.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_orm/class_subclass/_main.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="false" DocrootFlag="false" DirectorySuffix="" TargetDirectory="<?php echo __MODEL__  ?>" TargetFileName="<?php echo $objTable->ClassName  ?>.class.php"/>
+<?php
+	/** @var QTable $objTable */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => false,
+		'DocrootFlag' => false,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __MODEL__,
+		'TargetFileName' => $objTable->ClassName . '.class.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	require(__MODEL_GEN__ . '/<?php echo $objTable->ClassName  ?>Gen.class.php');
 

--- a/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qform_edit.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qform_edit.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="false" DocrootFlag="true" DirectorySuffix="" TargetDirectory="<?php echo __FORM_DRAFTS__  ?>" TargetFileName="<?php echo QConvertNotation::UnderscoreFromCamelCase($objTable->ClassName)  ?>_edit.php"/>
+<?php
+	/** @var QTable $objTable */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => false,
+		'DocrootFlag' => true,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __FORM_DRAFTS__,
+		'TargetFileName' => QConvertNotation::UnderscoreFromCamelCase($objTable->ClassName) . '_edit.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	// Load the QCubed Development Framework
 	require('../qcubed.inc.php');

--- a/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qform_edit_base.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qform_edit_base.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="true" DocrootFlag="false" DirectorySuffix="" TargetDirectory="<?php echo __FORMBASE_CLASSES__  ?>" TargetFileName="<?php echo $objTable->ClassName  ?>EditFormBase.class.php"/>
+<?php
+	/** @var QTable $objTable */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => true,
+		'DocrootFlag' => false,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __FORMBASE_CLASSES__,
+		'TargetFileName' => $objTable->ClassName . 'EditFormBase.class.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	/**
 	 * This is a quick-and-dirty draft QForm object to do Create, Edit, and Delete functionality

--- a/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qform_edit_include.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qform_edit_include.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="true" DocrootFlag="true" DirectorySuffix="" TargetDirectory="<?php echo __FORM_DRAFTS__  ?>" TargetFileName="<?php echo QConvertNotation::UnderscoreFromCamelCase($objTable->ClassName)  ?>_edit.tpl.php"/>
+<?php
+	/** @var QTable $objTable */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => true,
+		'DocrootFlag' => true,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __FORM_DRAFTS__,
+		'TargetFileName' => QConvertNotation::UnderscoreFromCamelCase($objTable->ClassName) . '_edit.tpl.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	// This is the HTML template include file (.tpl.php) for the <?php echo QConvertNotation::UnderscoreFromCamelCase($objTable->ClassName)  ?>_edit.php
 	// form DRAFT page.  Remember that this is a DRAFT.  It is MEANT to be altered/modified.

--- a/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qform_list.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qform_list.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="false" DocrootFlag="true" DirectorySuffix="" TargetDirectory="<?php echo __FORM_DRAFTS__  ?>" TargetFileName="<?php echo QConvertNotation::UnderscoreFromCamelCase($objTable->ClassName)  ?>_list.php"/>
+<?php
+	/** @var QTable $objTable */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => false,
+		'DocrootFlag' => true,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __FORM_DRAFTS__,
+		'TargetFileName' => QConvertNotation::UnderscoreFromCamelCase($objTable->ClassName) . '_list.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	// Load the QCubed Development Framework
 	require('../qcubed.inc.php');

--- a/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qform_list_base.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qform_list_base.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="true" DocrootFlag="false" DirectorySuffix="" TargetDirectory="<?php echo __FORMBASE_CLASSES__  ?>" TargetFileName="<?php echo $objTable->ClassName  ?>ListFormBase.class.php"/>
+<?php
+	/** @var QTable $objTable */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => true,
+		'DocrootFlag' => false,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __FORMBASE_CLASSES__,
+		'TargetFileName' => $objTable->ClassName . 'ListFormBase.class.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	/**
 	 * This is a quick-and-dirty draft QForm object to do the List All functionality

--- a/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qform_list_include.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qform_list_include.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="true" DocrootFlag="true" DirectorySuffix="" TargetDirectory="<?php echo __FORM_DRAFTS__  ?>" TargetFileName="<?php echo QConvertNotation::UnderscoreFromCamelCase($objTable->ClassName)  ?>_list.tpl.php"/>
+<?php
+	/** @var QTable $objTable */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => true,
+		'DocrootFlag' => true,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __FORM_DRAFTS__,
+		'TargetFileName' => QConvertNotation::UnderscoreFromCamelCase($objTable->ClassName) . '_list.tpl.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	// This is the HTML template include file (.tpl.php) for the <?php echo QConvertNotation::UnderscoreFromCamelCase($objTable->ClassName)  ?>_list.php
 	// form DRAFT page.  Remember that this is a DRAFT.  It is MEANT to be altered/modified.

--- a/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qpanel_edit.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qpanel_edit.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="true" DocrootFlag="true" DirectorySuffix="" TargetDirectory="<?php echo __PANEL_DRAFTS__  ?>" TargetFileName="<?php echo $objTable->ClassName  ?>EditPanel.class.php"/>
+<?php
+	/** @var QTable $objTable */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => true,
+		'DocrootFlag' => true,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __PANEL_DRAFTS__,
+		'TargetFileName' => $objTable->ClassName . 'EditPanel.class.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	/**
 	 * This is a quick-and-dirty draft QPanel object to do Create, Edit, and Delete functionality

--- a/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qpanel_edit_template.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qpanel_edit_template.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="true" DocrootFlag="true" DirectorySuffix="" TargetDirectory="<?php echo __PANEL_DRAFTS__  ?>" TargetFileName="<?php echo $objTable->ClassName ?>EditPanel.tpl.php"/>
+<?php
+	/** @var QTable $objTable */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => true,
+		'DocrootFlag' => true,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __PANEL_DRAFTS__,
+		'TargetFileName' => $objTable->ClassName . 'EditPanel.tpl.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	// This is the HTML template include file (.tpl.php) for <?php echo QConvertNotation::UnderscoreFromCamelCase($objTable->ClassName)  ?>EditPanel.
 	// Remember that this is a DRAFT.  It is MEANT to be altered/modified.

--- a/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qpanel_list.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qpanel_list.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="true" DocrootFlag="true" DirectorySuffix="" TargetDirectory="<?php echo __PANEL_DRAFTS__  ?>" TargetFileName="<?php echo $objTable->ClassName  ?>ListPanel.class.php"/>
+<?php
+	/** @var QTable $objTable */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => true,
+		'DocrootFlag' => true,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __PANEL_DRAFTS__,
+		'TargetFileName' => $objTable->ClassName . 'ListPanel.class.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	/**
 	 * This is the abstract Panel class for the List All functionality

--- a/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qpanel_list_template.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_orm/drafts/_qpanel_list_template.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="true" DocrootFlag="true" DirectorySuffix="" TargetDirectory="<?php echo __PANEL_DRAFTS__  ?>" TargetFileName="<?php echo $objTable->ClassName  ?>ListPanel.tpl.php"/>
+<?php
+	/** @var QTable $objTable */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => true,
+		'DocrootFlag' => true,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __PANEL_DRAFTS__,
+		'TargetFileName' => $objTable->ClassName . 'ListPanel.tpl.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	// This is the HTML template include file (.tpl.php) for <?php echo $objTable->ClassName  ?>ListPanel.
 	// Remember that this is a DRAFT.  It is MEANT to be altered/modified.

--- a/includes/qcubed/_core/codegen/templates/db_orm/meta_control/_main.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_orm/meta_control/_main.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="true" DocrootFlag="false" DirectorySuffix="" TargetDirectory="<?php echo __META_CONTROLS_GEN__  ?>" TargetFileName="<?php echo $objTable->ClassName  ?>MetaControlGen.class.php"/>
+<?php
+	/** @var QTable $objTable */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => true,
+		'DocrootFlag' => false,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __META_CONTROLS_GEN__,
+		'TargetFileName' => $objTable->ClassName . 'MetaControlGen.class.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	/**
 	 * This is a MetaControl class, providing a QForm or QPanel access to event handlers

--- a/includes/qcubed/_core/codegen/templates/db_orm/meta_control/_subclass.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_orm/meta_control/_subclass.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="false" DocrootFlag="false" DirectorySuffix="" TargetDirectory="<?php echo __META_CONTROLS__  ?>" TargetFileName="<?php echo $objTable->ClassName  ?>MetaControl.class.php"/>
+<?php
+	/** @var QTable $objTable */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => false,
+		'DocrootFlag' => false,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __META_CONTROLS__,
+		'TargetFileName' => $objTable->ClassName . 'MetaControl.class.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	require(__META_CONTROLS_GEN__ . '/<?php echo $objTable->ClassName  ?>MetaControlGen.class.php');
 

--- a/includes/qcubed/_core/codegen/templates/db_orm/meta_datagrid/_main.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_orm/meta_datagrid/_main.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="true" DocrootFlag="false" DirectorySuffix="" TargetDirectory="<?php echo __META_CONTROLS_GEN__  ?>" TargetFileName="<?php echo $objTable->ClassName  ?>DataGridGen.class.php"/>
+<?php
+	/** @var QTable $objTable */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => true,
+		'DocrootFlag' => false,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __META_CONTROLS_GEN__,
+		'TargetFileName' => $objTable->ClassName . 'DataGridGen.class.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	/**
 	 * This is the "Meta" DataGrid class for the List functionality

--- a/includes/qcubed/_core/codegen/templates/db_orm/meta_datagrid/_subclass.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_orm/meta_datagrid/_subclass.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="false" DocrootFlag="false" DirectorySuffix="" TargetDirectory="<?php echo __META_CONTROLS__  ?>" TargetFileName="<?php echo $objTable->ClassName  ?>DataGrid.class.php"/>
+<?php
+	/** @var QTable $objTable */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => false,
+		'DocrootFlag' => false,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __META_CONTROLS__,
+		'TargetFileName' => $objTable->ClassName . 'DataGrid.class.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	require(__META_CONTROLS_GEN__ . '/<?php echo $objTable->ClassName  ?>DataGridGen.class.php');
 

--- a/includes/qcubed/_core/codegen/templates/db_type/class_gen/_main.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_type/class_gen/_main.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="true" DocrootFlag="false" DirectorySuffix="" TargetDirectory="<?php echo __MODEL_GEN__  ?>" TargetFileName="<?php echo $objTypeTable->ClassName  ?>Gen.class.php"/>
+<?php
+	/** @var QTypeTable $objTypeTable */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => true,
+		'DocrootFlag' => false,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __MODEL_GEN__,
+		'TargetFileName' => $objTypeTable->ClassName . 'Gen.class.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	/**
 	 * The <?php echo $objTypeTable->ClassName  ?> class defined here contains

--- a/includes/qcubed/_core/codegen/templates/db_type/class_subclass/_main.tpl.php
+++ b/includes/qcubed/_core/codegen/templates/db_type/class_subclass/_main.tpl.php
@@ -1,4 +1,15 @@
-<template OverwriteFlag="false" DocrootFlag="false" DirectorySuffix="" TargetDirectory="<?php echo __MODEL__  ?>" TargetFileName="<?php echo $objTypeTable->ClassName  ?>.class.php"/>
+<?php
+	/** @var QTypeTable $objTypeTable */
+	/** @var QDatabaseCodeGen $objCodeGen */
+	global $_TEMPLATE_SETTINGS;
+	$_TEMPLATE_SETTINGS = array(
+		'OverwriteFlag' => false,
+		'DocrootFlag' => false,
+		'DirectorySuffix' => '',
+		'TargetDirectory' => __MODEL__,
+		'TargetFileName' => $objTypeTable->ClassName . '.class.php'
+	);
+?>
 <?php print("<?php\n"); ?>
 	require(__MODEL_GEN__ . '/<?php echo $objTypeTable->ClassName  ?>Gen.class.php');
 


### PR DESCRIPTION
This patch replaces the current way of specifying the template settings with an XML tag like `<template OverwriteFlag=.../>` as the first line of PHP template files.
The new way is a pure PHP implementation, where the template simply sets a special variable like this:

``` php
<?php
    global $_TEMPLATE_SETTINGS;
    $_TEMPLATE_SETTINGS = array(
        'OverwriteFlag' => false,
        'DocrootFlag' => false,
        'DirectorySuffix' => '',
        'TargetDirectory' => __MODEL__,
        'TargetFileName' => $objTypeTable->ClassName . '.class.php'
    );
?>
```

Note that the change preserves backward compatibility (i.e. it falls back to the XML tag if the `$_TEMPLATE_SETTINGS` is not defined). This is necessary to make sure the existing user templates are still properly processed.
