### PR TITLE
Update QConvertNotationBase.class.php

### DIFF
--- a/includes/qcubed/_core/codegen/QConvertNotationBase.class.php
+++ b/includes/qcubed/_core/codegen/QConvertNotationBase.class.php
@@ -3,7 +3,6 @@
 	* @package Codegen
 	*/
 
-	// NOTATIONS: http://www.cob.sjsu.edu/johnson_f/notation.htm
 	abstract class QConvertNotationBase {
 		public static function PrefixFromType($strType) {
 			switch ($strType) {


### PR DESCRIPTION
// http://www.cob.sjsu.edu/johnson_f/notation.htm is now a deadlink, is there another source we can reference?
