### PR TITLE
Fix sample.php

### DIFF
--- a/sample.php
+++ b/sample.php
@@ -12,7 +12,7 @@
 		protected $btnButton;
 
 		protected function Form_Create() {
-			$this->lblMessage = new QDatepickerBox($this);
+			$this->lblMessage = new QLabel($this);
 			$this->lblMessage->Text = 'Click the button to change my message.';
 			
 			$this->btnButton = new QButton($this);


### PR DESCRIPTION
Sample.php in the framework root directory crashes after a new checkout
of the wrong Object type for the lblMessage. This commit fixes the issue
