### PR TITLE
Fix the case when the subdirectory is not needed

### DIFF
--- a/assets/_core/php/_devtools/installer/step_2.php
+++ b/assets/_core/php/_devtools/installer/step_2.php
@@ -70,6 +70,10 @@
 	if (DIRECTORY_SEPARATOR !== mb_substr($strSubDirectory, 0, 1)) {
 		$strSubDirectory = DIRECTORY_SEPARATOR . $strSubDirectory;
 	}
+	
+	if ($strSubDirectory == DIRECTORY_SEPARATOR) {
+		$strSubDirectory = '';
+	}
 
 	// Make sure the installation directory supplied exists
 	if(!is_dir($strInstallationDir)) {


### PR DESCRIPTION
When the installer detects that **SUBDIRECTORY** is blank, it sets it
as ‘/‘. This patch fixes it.
