### PR TITLE
Warning  if there is a config problem.

### DIFF
--- a/includes/watchers/QWatcherBase.class.php
+++ b/includes/watchers/QWatcherBase.class.php
@@ -48,6 +48,10 @@
 		public function Watch(QQNode $objNode) {
 			$strClassName = $objNode->_ClassName;
 
+			if (!$strClassName::$blnWatchChanges) {
+				throw new QCallerException ($strClassName . ':$blnWatchChanges is false. To be able to watch this table, you should set it to true in your ' . $strClassName . '.class.php file.');
+			}
+
 			if ($strClassName) {
 				$objDatabase = $strClassName::GetDatabase();
 				$this->RegisterTable($objDatabase->Database, $objNode->_TableName);


### PR DESCRIPTION
If you forget to configure a table to be watched, it would silently fail. This adds a warning if you are trying to watch a table that has not been configured to be watched.
