### PR TITLE
bugfix - QTabs Refresh Problem

### DIFF
--- a/includes/base_controls/QTabsBase.class.php
+++ b/includes/base_controls/QTabsBase.class.php
@@ -139,6 +139,16 @@
 		}
 
 		/**
+		 * Generated method overrides the built-in QControl method, causing it to not redraw completely. We restore
+		 * its functionality here.
+		 */
+		public function Refresh() {
+			$this->CallJqUiMethod(false, "refresh");
+			QControl::Refresh();
+		}
+
+
+		/**
 		 * Overrides default so that if a tab does not pass validation, it will be visible.
 		 * @return bool
 		 */


### PR DESCRIPTION
The jqueryui code for tabs includes a "refresh" method which conflicts with the QControl refresh. The jqueryui version causes the javascript to reread the dom to recreate the tabs, while the QControl version redraws the entire control. Redrawing the entire control is important to regenerate the dom if it changed. This fix calls both the QControl version and the jqueryui version to sync them.
