### PR TITLE
Adding ability to turn off subject encoding. Useful for emailing to SMS. 2nd try.

### DIFF
--- a/includes/framework/QEmailServer.class.php
+++ b/includes/framework/QEmailServer.class.php
@@ -511,6 +511,8 @@
 	}
 
 	/**
+	 * An email message that you can send with QEmailServer
+	 *
 	 * @property string $From
 	 * @property string $ReplyTo
 	 * @property string $Sender
@@ -520,6 +522,7 @@
 	 * @property string $Subject
 	 * @property string $Body
 	 * @property string $HtmlBody
+	 * @property boolean $EncodeSubject  Whether to encode the subject of the email using UTF-8. Default is true. You might want to turn this off if sending to text message portals (i.e. 123-4567@sprint.message.com)
 	 */
 	class QEmailMessage extends QBaseClass {
 		protected $strFrom;


### PR DESCRIPTION
This gives you the ability to turn off subject encoding. This is important if you are emailing to SMS portals. (For example, `5551234567@vtext.com` will mail a text message to a verizon customer).

The problem is that many SMS portals do not handle encoded subjects. See http://kb.paessler.com/en/topic/46873-why-do-sms-notifications-have-a-subject-like-subj:-utf-8-b-z29iymxlzglnb29r
for an example of the kinds of problems that UTF-8 encoded subjects can cause these portals. The problems still exist today. 

So, if you know you are emailing a text message, you can use this new ability to avoid the garbage that shows up in the text message. Its not mail standard, but its necessary.
