### PR TITLE
bugfix-NoIdOnCheckbox

### DIFF
--- a/assets/js/qcubed.js
+++ b/assets/js/qcubed.js
@@ -179,13 +179,15 @@ qcubed = {
                 strControlId = $element.attr("id");
 
                 // RadioButtonList or CheckBoxList
-                if (strControlId.indexOf('_') >= 0) {
-                    if (strControlId.indexOf('_0') >= 0) {
-                        strToReturn += " " + strControlId.substring(0, strControlId.length - 2);
+                if (strControlId) {
+                    if (strControlId.indexOf('_') >= 0) {
+                        if (strControlId.indexOf('_0') >= 0) {
+                            strToReturn += " " + strControlId.substring(0, strControlId.length - 2);
+                        }
+                        // Standard Radio or Checkbox
+                    } else {
+                        strToReturn += " " + strControlId;
                     }
-                    // Standard Radio or Checkbox
-                } else {
-                    strToReturn += " " + strControlId;
                 }
             }
         });


### PR DESCRIPTION
Checking for a blank id before we try to look for something in it. If you place a checkbox in your html that has no id, this would crash.
