### PR TITLE
bugfix-FormValidationAndDialog

### DIFF
--- a/includes/base_controls/QFormBase.class.php
+++ b/includes/base_controls/QFormBase.class.php
@@ -1123,7 +1123,7 @@
 
 
 						// Run Form-Specific Validation (if any)
-						if ($mixCausesValidation) {
+						if ($mixCausesValidation && !($mixCausesValidation instanceof QDialog)) {
 							if (!$this->Form_Validate()) {
 								$blnValid = false;
 							}


### PR DESCRIPTION
If a dialog button is causing a validation, we are going to assume that it is causing validation for the dialog itself, and not validating the entire form. We are assuming that the dialog itself is not going to also submit the form. If in the rare case the developer would like the dialog to submit the form, he could override this behavior in a subclass of the dialog, or in the action itself.
