### PR TITLE
Bugfix delayed actions with param

### DIFF
--- a/includes/base_controls/_actions.inc.php
+++ b/includes/base_controls/_actions.inc.php
@@ -45,7 +45,7 @@
 				if (strpos ($strScript, '__PARAM__')) {
 					// a script that uses an action parameter.
 					$strActionParam = $objAction->getActionParameter($objControl);
-					if (!$strActionParam) {
+					if ($strActionParam === null || $strActionParam === '') {
 						$strActionParam = "''"; // empty string to be inserted into javascript
 					}
 					if ($objAction->objEvent->Delay > 0) {


### PR DESCRIPTION
FIxing problem where delayed actions do not have their action parameter evaluated at the right time. This fix evaluates the action parameter, then inserts the value found into the function called when setTimeout is called. Otherwise, everything else is as it was. The fix only affects server and ajax actions.

This fix might cause problems if someone has subclassed the server and ajax action classes, but that is unlikely, and this is an alpha stage fix anyways.
