### PR TITLE
bugfix-ProtectedQAjaxControlAction

### DIFF
--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -367,6 +367,19 @@
 		}
 
 		/**
+		 * Used by the QForm engine to call the method in the control, allowing the method to be a protected method.
+		 *
+		 * @param QControl $objControl
+		 * @param $strMethodName
+		 * @param $strFormId
+		 * @param $strId
+		 * @param $strParameter
+		 */
+		public static function CallActionMethod(QControl $objControl, $strMethodName, $strFormId, $strId, $strParameter) {
+			$objControl->$strMethodName($strFormId, $strId, $strParameter);
+		}
+
+		/**
 		 * Adds a control as a child of this control.
 		 *
 		 * @param QControl|QControlBase $objControl the control to add

--- a/includes/base_controls/QFormBase.class.php
+++ b/includes/base_controls/QFormBase.class.php
@@ -993,7 +993,7 @@
 				$strMethodName = substr($strMethodName, $intPosition + 1);
 
 				$objControl = $this->objControlArray[$strControlName];
-				$objControl->$strMethodName($this->strFormId, $strId, $strParameter);
+				QControl::CallActionMethod ($objControl, $strMethodName, $this->strFormId, $strId, $strParameter);
 			} else
 				$this->$strMethodName($this->strFormId, $strId, $strParameter);
 		}


### PR DESCRIPTION
This is a problem that has bugged me for a while. Currently, if you use QAjaxControlAction, you must specify that the method is public. If you don't, it will silently fail. This fix allows protected methods for control actions.
