### PR TITLE
regression-UnserializingDateTime

### DIFF
--- a/includes/framework/QDateTime.class.php
+++ b/includes/framework/QDateTime.class.php
@@ -268,7 +268,7 @@
 		protected $strSerializedTZ;
 		public function __sleep() {
 			$tz = $this->getTimezone();
-			if ($tz && strpos ($tz->getName(), '/') !== false) {
+			if ($tz && in_array ($tz->getName(), timezone_identifiers_list())) {
 				// valid relative timezone name found
 				$this->strSerializedData = parent::format('Y-m-d H:i:s');
 				$this->strSerializedTZ = $tz->getName();
@@ -475,7 +475,7 @@
 				}
 				// normalize the timezones
 				$tz = $this->getTimezone();
-				if ($tz && strpos ($tz->getName(), '/') !== false) {
+				if ($tz && in_array ($tz->getName(), timezone_identifiers_list())) {
 					// php limits you to ID only timezones here, so make sure we have one of those
 					$mixValue->setTimezone ($tz);
 				}


### PR DESCRIPTION
This fixes a problem I introduced in the last QDateTime cleanup. I assumed that the unserialize bug was PHP 5.2 only. It is still in PHP 5.4. PHP cannot use unserialized DateTime objects. This fix reinstates the previous code to handle unserializing, and adds the additional fix to the old code to correctly preserve the timezone. The old code converted the ID timezone to an offset timezone, which can cause havoc with calculations across daylight savings time boundaries.

This fix also does some checks to make sure getTimezone returns a value. PHP manual says it could return false.
