### PR TITLE
bugfix-DelayedActionParams

### DIFF
--- a/assets/js/qcubed.js
+++ b/assets/js/qcubed.js
@@ -460,9 +460,9 @@ qcubed.clearTimeout = function(strTimerId) {
     }
 };
 
-qcubed.setTimeout = function(strTimerId, strAction, intDelay) {
+qcubed.setTimeout = function(strTimerId, action, intDelay) {
     qcubed.clearTimeout(strTimerId);
-    qcubed._objTimers[strTimerId] = setTimeout(strAction, intDelay);
+    qcubed._objTimers[strTimerId] = setTimeout(action, intDelay);
 };
 
 ///////////////////////////////

--- a/includes/base_controls/_actions.inc.php
+++ b/includes/base_controls/_actions.inc.php
@@ -42,9 +42,9 @@
 				}
 
 				if ($objAction->objEvent->Delay > 0) {
-					$strCode = sprintf(" qcubed.setTimeout('%s', '%s', %s);",
+					$strCode = sprintf(" qcubed.setTimeout('%s', \$j.proxy(function(){%s},this), %s);",
 						$objControl->ControlId,
-						addslashes($objAction->RenderScript($objControl)),
+						$objAction->RenderScript($objControl),
 						$objAction->objEvent->Delay);
 				} else {
 					$strCode = ' ' . $objAction->RenderScript($objControl);


### PR DESCRIPTION
jQuery has a function to restore the 'this' context. We use ti for delayed actions so the action param can correctly use it to find things like row ids.
