### PR TITLE
bigfix-TabSelection

### DIFF
--- a/assets/php/examples/other_controls/jq_example.php
+++ b/assets/php/examples/other_controls/jq_example.php
@@ -261,6 +261,7 @@
 			$tab3 = new QPanel($this->Tabs);
 			$tab3->Text = 'Tab 3';
 			$this->Tabs->Headers = array('One', 'Two', 'Three');
+			$this->Tabs->AddAction (new QTabs_ActivateEvent(), new QAjaxAction('tabs_change'));
 		}
 
 		protected function update_autocompleteList($strFormId, $strControlId, $strParameter) {
@@ -367,6 +368,14 @@
 				$this->Datepicker->DateTime = $this->DatepickerBox->DateTime;
 			}
 		}
+
+		protected function tabs_change($strFormId, $strControlId, $strParameter) {
+			$index = $this->Tabs->Active;
+			$id = $this->Tabs->SelectedId;
+			$strItems = $index . ', ' . $id;
+			QApplication::DisplayAlert ($strItems);
+		}
+
 	}
     ExampleForm::Run('ExampleForm');
 ?>


### PR DESCRIPTION
JQuery UI 1.9 changed the interface for Tabs. This fix uses the new interface to keep track of the selected index and id. It also allows the user to active a tab by name, index or ControlId. Some other cleanups are here too.
