### PR TITLE
Strange use of class names in renderwitherror

### DIFF
--- a/includes/qcubed/_core/base_controls/QControlBase.class.php
+++ b/includes/qcubed/_core/base_controls/QControlBase.class.php
@@ -1365,7 +1365,7 @@
 				$strOutput = $this->GetControlHtml();
 
 				if ($this->strValidationError)
-					$strOutput .= sprintf('<br %s/><span %sclass="warning">%s</span>', $strDataRel, $strDataRel, $this->strValidationError);
+					$strOutput .= sprintf('<br %s/><span %sclass="error">%s</span>', $strDataRel, $strDataRel, $this->strValidationError);
 				else if ($this->strWarning)
 					$strOutput .= sprintf('<br %s/><span %sclass="warning">%s</span>', $strDataRel, $strDataRel, $this->strWarning);
 			} catch (QCallerException $objExc) {
@@ -1435,7 +1435,7 @@
 			if ($this->strValidationError){
 				$strMessage = sprintf('<span class="error">%s</span>', $this->strValidationError);
 			}else if ($this->strWarning){
-				$strMessage = sprintf('<span class="error">%s</span>', $this->strWarning);
+				$strMessage = sprintf('<span class="warning">%s</span>', $this->strWarning);
 			}
 			
 			try {


### PR DESCRIPTION
When a control is invalid the renderwithname will render a span with class error
the renderwitherror function will render a span with class warning. 

I think this has to be changed depending on an error or a warning. And it should be consistent across functions.
