### PR TITLE
bugfix-CURRENT_TIMESTAMP

### DIFF
--- a/includes/codegen/templates/db_orm/class_gen/protected_member_variables.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/protected_member_variables.tpl.php
@@ -18,10 +18,14 @@
 		const <?= $objColumn->PropertyName ?>Default = <?php
 	if (is_null($objColumn->Default))
 		print 'null';
-	else if (is_numeric($objColumn->Default))
+	elseif (is_numeric($objColumn->Default))
 		print $objColumn->Default;
-	else
+	elseif ($objColumn->Default == 'CURRENT_TIMESTAMP') {
+		print 'QDateTime::Now';
+	}
+	else {
 		print "'" . addslashes($objColumn->Default) . "'";
+	}
 ?>;
 
 <?php if ((!$objColumn->Identity) && ($objColumn->PrimaryKey)) { ?>


### PR DESCRIPTION
This is a regression fix for the recent QDateTime changes. PHP has a bug that if you try to initialize a datetime with a random string, PHP will actually crash completely. Now that we are allowing timestamps to be QDateTime objects, it is possible for a QDateTime to be initialized with CURRENT_TIMESTAMP. This string will appear in the initialization string for the QDateTime, thus bringing PHP to its knees. This fix recognizes the string for what it is, and attempt to set the date time to the current date and time.
