### PR TITLE
bugfix-Examples

### DIFF
--- a/assets/php/examples/datagrid/simple_table.php
+++ b/assets/php/examples/datagrid/simple_table.php
@@ -56,10 +56,7 @@ class ExampleForm extends QForm {
 		$this->tblPersons->HeaderRowCssClass = 'header_row';
 
 		// Define Columns
-		$objColumn = new QSimpleTableClosureColumn('Full Name',
-							function($item) {
-								return 'Full Name is "' . $item->FirstName . ' ' . $item->LastName . '"';
-							});
+		$objColumn = new QSimpleTableCallableColumn('Full Name', 'ExampleForm::getFullName');
 		$this->tblPersons->AddColumn($objColumn);
 
 		// The second column demonstrates using a property name for fetching the data

--- a/assets/php/examples/datagrid/simple_table.tpl.php
+++ b/assets/php/examples/datagrid/simple_table.tpl.php
@@ -36,11 +36,13 @@
 
 	<p>Also, similar to QDataGrid, you must define a new column object for each column in your table.
 		And this is where the differences with QDataGrid begin. While QDataGrid uses a string with php code in special tags
-		to specify how the values for each cell have to be fetched from the DataSource object rows, QSimpleTable uses user
-		specified functions (or <a href="http://php.net/manual/en/functions.anonymous.php">PHP 5.3 Closures</a>). This means that
+		to specify how the values for each cell have to be fetched from the DataSource object rows, QSimpleTable uses
+		<a href="http://php.net/manual/en/language.types.callable.php">user specified callback functions</a>). This means that
 		unlike QDataGrid, QSimpleTable <strong>does not</strong> use the PHP eval() function to calculate the cell values.
 		PHP's eval(), while a very powerful tool, has many drawbacks such as potential security risks and difficulties it
-		creates for optimizing compilers.</p>
+		creates for optimizing compilers. The one caveat is that you cannot use PHP <strong>Closures</strong>strong> as
+		functions, because QCubed needs to serialize everything in the form to preserve its state, and closures cannot
+		be serialized.</p>
 
 	<p>The column objects for QSimpleTable must be of type <strong>QAbstractSimpleTableColumn</strong>. There are three such built in
 		classes:</p>
@@ -50,12 +52,12 @@
 			property on the items in the DataSource array.</li>
 		<li><strong>QSimpleTableIndexedColumn</strong>: this is useful when the DataSource items are arrays and the cell
 			values are the elements of those arrays.</li>
-		<li><strong>QSimpleTableClosureColumn</strong>: this is the most powerful of the tree and is useful when fetching the cell
+		<li><strong>QSimpleTableCallableColumn</strong>: this is useful when fetching the cell
 			data requires complex application logic.</li>
 	</ul>
 
 	<p>These columns can be created and added to the table using the QSimpleTable::CreatePropertyColumn(),
-		QSimpleTable::CreateIndexedColumn() and QSimpleTable::CreateClosureColumn() methods respectively. Of course they can also be
+		QSimpleTable::CreateIndexedColumn() and QSimpleTable::CreateCallableColumn() methods respectively. Of course they can also be
 		constructed directly, and added using QSimpleTable::AddColumn methods.</p>
 
 	<p>Note, that as the name indicates, QSimpleTable is very simple, it does not provide several of the features that are
@@ -69,9 +71,9 @@
 
 	<h2>First Example</h2>
 
-	<p>The first example demonstrates how to use property and closure based columns when the DataSource is an array of objects.</p>
+	<p>The first example demonstrates how to use property and callable based columns when the DataSource is an array of objects.</p>
 
-	<p>The first column is using a Closure, to
+	<p>The first column is using a Callable, to
 		compute the value of the cells.</p>
 
 	<p>The second column uses the "LastName" property to get the value of the cells.</p>

--- a/assets/php/examples/dynamic/pnl_panel.tpl.php
+++ b/assets/php/examples/dynamic/pnl_panel.tpl.php
@@ -1,3 +1,3 @@
 <h3>This is the Panel of Textboxes</h3>
-Note how we can still use <b>$this</b> in the template to refer to form-level objects, like <b>$this->strMessage</b>:
-"<?php _p($this->strMessage); ?>"<br/><br/>
+Note how we can use <b>$this</b> in the template to refer to the control, like <b>$this->Form->strMessage</b>:
+"<?php _p($this->Form->strMessage); ?>"<br/><br/>

--- a/assets/php/examples/dynamic/qpanel.php
+++ b/assets/php/examples/dynamic/qpanel.php
@@ -11,7 +11,7 @@
 		protected $pnlFieldset;
 
 		// For this example, show how the panel can display this strMessage
-		protected $strMessage = 'Hello, world!';
+		public $strMessage = 'Hello, world!';
 
 		protected function Form_Create() {
 			// Define the Panel

--- a/assets/php/examples/dynamic/qpanel.tpl.php
+++ b/assets/php/examples/dynamic/qpanel.tpl.php
@@ -38,6 +38,9 @@
 	<p>Note that even though 10 textboxes are being rendered, we never explicitly code a <strong>QTextBox->Render</strong>
 	call <em>anywhere</em> in our code.</p>
 
+	<p>Within the template file, the <em>$this</em> variable refers to the control being rendered.</em></p>
+
+
 	<p>Another type of block control to mention here is the  <strong>QFieldset</strong>
 		which draws a panel as an html fieldset, and has a legend. Otherwise, it is the same as a QPanel.</p>
 

--- a/assets/php/examples/dynamic/qpanel_2.php
+++ b/assets/php/examples/dynamic/qpanel_2.php
@@ -16,9 +16,11 @@
 			// Define the Panels
 			$this->pnlLeft = new QPanel($this);
 			$this->pnlLeft->CssClass = 'textbox_panel';
+			$this->pnlLeft->Width = 250;
 
 			$this->pnlRight = new QPanel($this);
 			$this->pnlRight->CssClass = 'textbox_panel';
+			$this->pnlRight->Width = 250;
 
 			// Let's have the panels auto render any and all child controls
 			$this->pnlLeft->AutoRenderChildren = true;

--- a/assets/php/examples/master_detail/AddressListPanel.class.php
+++ b/assets/php/examples/master_detail/AddressListPanel.class.php
@@ -28,7 +28,7 @@
 
 		protected $metaAddress;
 		protected $lblId;
-		protected $lblPersonId;
+		protected $lblPerson;
 		protected $txtStreet;
 		protected $txtCity;
 
@@ -103,9 +103,9 @@
 			$this->lblId->AddAction(new QEscapeKeyEvent(), new QAjaxControlAction($this,'btnCancel_Click',$this->dtgAddresses->WaitIcon));
 			$this->lblId->AddAction(new QEscapeKeyEvent(), new QTerminateAction());
 
-			$this->lblPersonId = $this->metaAddress->lblPersonId_Create();
-			$this->lblPersonId->AddAction(new QEscapeKeyEvent(), new QAjaxControlAction($this,'btnCancel_Click',$this->dtgAddresses->WaitIcon));
-			$this->lblPersonId->AddAction(new QEscapeKeyEvent(), new QTerminateAction());
+			$this->lblPerson = $this->metaAddress->lblPerson_Create();
+			$this->lblPerson->AddAction(new QEscapeKeyEvent(), new QAjaxControlAction($this,'btnCancel_Click',$this->dtgAddresses->WaitIcon));
+			$this->lblPerson->AddAction(new QEscapeKeyEvent(), new QTerminateAction());
 
 			$this->txtStreet = $this->metaAddress->txtStreet_Create();
 			$this->txtStreet->AddAction(new QEscapeKeyEvent(), new QAjaxControlAction($this,'btnCancel_Click',$this->dtgAddresses->WaitIcon));
@@ -157,7 +157,7 @@
 		 public function render_PersonIdColumn($parControl, Address $objRecord) {
 			if (($objRecord->Id == $this->intEditAddressId) ||
 					(($this->intEditAddressId == -1) && (!$objRecord->Id))) {
-				return $this->lblPersonId->RenderWithError(false);
+				return $this->lblPerson->RenderWithError(false);
 			} else {
 				return QApplication::HtmlEntities($objRecord->PersonId);
 			}

--- a/includes/base_controls/QSimpleTableBase.class.php
+++ b/includes/base_controls/QSimpleTableBase.class.php
@@ -14,8 +14,7 @@
 	 * fetched from the datasource.</p>
 	 *
 	 * <p><i>NOTE</i>: Unlike QDataGrid, this class does not use eval() for evaluating the cell values. Instead, a variety of
-	 * methods can be used to fetch the data for cells, including callable objects such as
-	 * closures (introduced in PHP 5,3).</p>
+	 * methods can be used to fetch the data for cells, including callable objects.</p>
 	 *
 	 * @package Controls
 	 *
@@ -89,14 +88,14 @@
 		}
 
 		/**
-		 * Add a closure column and return it.
+		 * Add a callable column and return it.
 		 * 
 		 * @param string $strName column name
-		 * @param object $objClosure a closure object. Note that this can be an array.
+		 * @param object $objCallable a callable object. Note that this can be an array.
 		 * @param integer $intColumnIndex column position
 		 */
-		public function CreateClosureColumn($strName, $objClosure, $intColumnIndex = -1) {
-			$objColumn = new QSimpleTableClosureColumn($strName, $objClosure);
+		public function CreateCallableColumn($strName, $objCallable, $intColumnIndex = -1) {
+			$objColumn = new QSimpleTableCallableColumn($strName, $objCallable);
 			$this->AddColumnAt($intColumnIndex, $objColumn);
 			return $objColumn;
 		}

--- a/includes/base_controls/QTextBoxBase.class.php
+++ b/includes/base_controls/QTextBoxBase.class.php
@@ -137,7 +137,7 @@
 			// We load lazy to make sure that the library is not loaded every time 'prepend.inc.php'
 			// or 'qcubed.inc.php' is inlcuded. HTMLPurifier is a HUGE and SLOW library. Lazy loading
 			// keeps it simpler.
-			require_once(__VENDOR__ . '/ezyang/htmlpurifier/library/HTMLPurifier.auto.php');
+			require_once(__DOCROOT__ . __VENDOR_ASSETS__ . '/ezyang/htmlpurifier/library/HTMLPurifier.auto.php');
 
 			// We configure the default set of forbidden tags (elements) and attributes here
 			// so that the rules are applicable the moment CrossScripting is set to Purify.

--- a/includes/qcubed.inc.php
+++ b/includes/qcubed.inc.php
@@ -204,7 +204,7 @@
 	QApplicationBase::$ClassFile['qabstractsimpletabledatacolumn'] = __QCUBED_CORE__ . '/base_controls/QSimpleTableColumn.class.php';
 	QApplicationBase::$ClassFile['qsimpletablepropertycolumn'] = __QCUBED_CORE__ . '/base_controls/QSimpleTableColumn.class.php';
 	QApplicationBase::$ClassFile['qsimpletableindexedcolumn'] = __QCUBED_CORE__ . '/base_controls/QSimpleTableColumn.class.php';
-	QApplicationBase::$ClassFile['qsimpletableclosurecolumn'] = __QCUBED_CORE__ . '/base_controls/QSimpleTableColumn.class.php';
+	QApplicationBase::$ClassFile['qsimpletablecallablecolumn'] = __QCUBED_CORE__ . '/base_controls/QSimpleTableColumn.class.php';
 	QApplicationBase::$ClassFile['qsimpletablecheckboxcolumn'] = __QCUBED_CORE__ . '/base_controls/QSimpleTableColumn.class.php';
 	QApplicationBase::$ClassFile['qsimpletable'] = __QCUBED__ . '/controls/QSimpleTable.class.php';
 


### PR DESCRIPTION
Fixing example code, but while doing so, found a major problem with closure columns. We can't use closures in form objects because form objects must be serialized in order to recreate the form later.

So, I changed QSimpleTableClosureColumn to QSimpleTableCallableColumn to illustrate the difference between what is allowed, and what is not allowed.
