### PR TITLE
Added support for tsvector data type in postgresql

### DIFF
--- a/includes/database/QPostgreSqlDatabase.class.php
+++ b/includes/database/QPostgreSqlDatabase.class.php
@@ -746,6 +746,13 @@
 					//    not be able to use a QFloatTextBox -- only a regular QTextBox)
 					$this->strType = QDatabaseFieldType::VarChar;
 					break;
+				case 'tsvector':
+					// this is the TSVector data type in PostgreSQL used for full text search systems.
+					// It can safely be used as a text type for displaying the data.
+					// NOTE: It must be handled via custom queries.
+					// NOTE: It is added here to avoid code generator halting after error because of unrecognized type
+					$this->strType = QDatabaseFieldType::VarChar;
+					break;
 				case 'text':
 					$this->strType = QDatabaseFieldType::Blob;
 					break;


### PR DESCRIPTION
Added support for tsvector data type in postgresql so that code generator does not halt when it encounters a postgresql database that has a table with a column whose data type is tsvector.  

NOTE: tsvector data type is used for full text search (FTS) in PostgreSQL.
