### PR TITLE
bugfix-DatePickerDefault2

### DIFF
--- a/includes/base_controls/QDatepickerBoxBase.class.php
+++ b/includes/base_controls/QDatepickerBoxBase.class.php
@@ -26,7 +26,7 @@
 	 * @package Controls\Base
 	 */
 	class QDatepickerBoxBase extends QDatepickerBoxGen {
-		protected $strDateTimeFormat = "MM/DD/YY"; // matches default of JQuery UI control
+		protected $strDateTimeFormat = "MM/DD/YYYY"; // matches default of JQuery UI control
 		/** @var QDateTime */
 		protected $dttDateTime;
 


### PR DESCRIPTION
For some reason, this change got squashed by the other commits. This change makes the default date picker value have the same format as the javascript. Even thought the format strings don't look the same, the javascript version interprets 'yy' as having a four digit date.
