### PR TITLE
Added the inline-block display style

### DIFF
--- a/includes/base_controls/_enumerations.inc.php
+++ b/includes/base_controls/_enumerations.inc.php
@@ -32,10 +32,12 @@
 	abstract class QDisplayStyle {
 		/** Hide the control */
 		const None = 'none';
-		/** Treat as a block-control */
+		/** Treat as a block element */
 		const Block = 'block';
-		/** Treat as an inline-control */
+		/** Treat as an inline element */
 		const Inline = 'inline';
+		/** Treat as an inline-block element */
+		const InlineBlock = 'inline-block';
 		/** Display style not set. Browser will take care */
 		const NotSet = 'NotSet';
 	}


### PR DESCRIPTION
Added the 'inline-block' display style constant (InlineBlock) in the QDisplayStyle enumeration class. Also, I do not think there is any point in making this enumeration class exhaustive in nature hence not adding any more display types.
