### PR TITLE
bugfix-UnnecessaryRedraws

### DIFF
--- a/includes/base_controls/QBlockControl.class.php
+++ b/includes/base_controls/QBlockControl.class.php
@@ -315,13 +315,14 @@
 		 * @throws Exception|QInvalidCastException
 		 */
 		public function __set($strName, $mixValue) {
-			$this->blnModified = true;
-
 			switch ($strName) {
 				// APPEARANCE
 				case "Text":
 					try {
-						$this->strText = QType::Cast($mixValue, QType::String);
+						if ($this->strText !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strText = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -330,7 +331,10 @@
 
 				case "Format":
 					try {
-						$this->strFormat = QType::Cast($mixValue, QType::String);
+						if ($this->strFormat !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strFormat = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -339,6 +343,7 @@
 
 				case "Template":
 					try {
+						$this->blnModified = true;
 						if ($mixValue) {
 							if (file_exists($mixValue))
 								$this->strTemplate = QType::Cast($mixValue, QType::String);
@@ -354,7 +359,10 @@
 
 				case "AutoRenderChildren":
 					try {
-						$this->blnAutoRenderChildren = QType::Cast($mixValue, QType::Boolean);
+						if ($this->blnAutoRenderChildren !== ($mixValue = QType::Cast($mixValue, QType::Boolean))) {
+							$this->blnModified = true;
+							$this->blnAutoRenderChildren = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -363,7 +371,10 @@
 
 				case "TagName":
 					try {
-						$this->strTagName = QType::Cast($mixValue, QType::String);
+						if ($this->strTagName !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strTagName = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -372,7 +383,10 @@
 
 				case "HtmlEntities":
 					try {
-						$this->blnHtmlEntities = QType::Cast($mixValue, QType::Boolean);
+						if ($this->blnHtmlEntities !== ($mixValue = QType::Cast($mixValue, QType::Boolean))) {
+							$this->blnModified = true;
+							$this->blnHtmlEntities = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -381,7 +395,10 @@
 
 				case "Padding":
 					try {
-						$this->strPadding = QType::Cast($mixValue, QType::String);
+						if ($this->strPadding !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strPadding = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -390,7 +407,10 @@
 
 				case "DropTarget":
 					try {
-						$this->blnDropTarget = QType::Cast($mixValue, QType::Boolean);
+						if ($this->blnDropTarget !== ($mixValue = QType::Cast($mixValue, QType::Boolean))) {
+							$this->blnModified = true;
+							$this->blnDropTarget = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -399,7 +419,10 @@
 
 				case "HorizontalAlign":
 					try {
-						$this->strHorizontalAlign = QType::Cast($mixValue, QType::String);
+						if ($this->strHorizontalAlign !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strHorizontalAlign = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -408,7 +431,10 @@
 
 				case "VerticalAlign":
 					try {
-						$this->strVerticalAlign = QType::Cast($mixValue, QType::String);
+						if ($this->strVerticalAlign !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strVerticalAlign = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();

--- a/includes/base_controls/QCheckBoxList.class.php
+++ b/includes/base_controls/QCheckBoxList.class.php
@@ -322,13 +322,14 @@
 		// Public Properties: SET
 		/////////////////////////
 		public function __set($strName, $mixValue) {
-			$this->blnModified = true;
-
 			switch ($strName) {
 				// APPEARANCE
 				case "TextAlign":
 					try {
-						$this->strTextAlign = QType::Cast($mixValue, QType::String);
+						if ($this->strTextAlign !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strTextAlign = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -337,7 +338,10 @@
 
 				case "HtmlEntities":
 					try {
-						$this->blnHtmlEntities = QType::Cast($mixValue, QType::Boolean);
+						if ($this->blnHtmlEntities !== ($mixValue = QType::Cast($mixValue, QType::Boolean))) {
+							$this->blnModified = true;
+							$this->blnHtmlEntities = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -347,7 +351,10 @@
 				// LAYOUT
 				case "CellPadding":
 					try {
-						$this->intCellPadding = QType::Cast($mixValue, QType::Integer);
+						if ($this->intCellPadding !== ($mixValue = QType::Cast($mixValue, QType::Integer))) {
+							$this->blnModified = true;
+							$this->intCellPadding = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -355,7 +362,10 @@
 					}
 				case "CellSpacing":
 					try {
-						$this->intCellSpacing = QType::Cast($mixValue, QType::Integer);
+						if ($this->intCellSpacing !== ($mixValue = QType::Cast($mixValue, QType::Integer))) {
+							$this->blnModified = true;
+							$this->intCellSpacing = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -363,7 +373,10 @@
 					}
 				case "RepeatColumns":
 					try {
-						$this->intRepeatColumns = QType::Cast($mixValue, QType::Integer);
+						if ($this->intRepeatColumns !== ($mixValue = QType::Cast($mixValue, QType::Integer))) {
+							$this->blnModified = true;
+							$this->intRepeatColumns = $mixValue;
+						}
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
 						throw $objExc;
@@ -373,7 +386,10 @@
 					break;
 				case "RepeatDirection":
 					try {
-						$this->strRepeatDirection = QType::Cast($mixValue, QType::String);
+						if ($this->strRepeatDirection !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strRepeatDirection = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -381,6 +397,7 @@
 					}
 				case "ItemStyle":
 					try {
+						$this->blnModified = true;
 						$this->objItemStyle = QType::Cast($mixValue, "QListItemStyle");
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -390,7 +407,10 @@
 
 				case "ButtonMode":
 					try {
-						$this->intButtonMode = QType::Cast($mixValue, QType::Integer);
+						if ($this->intButtonMode !== ($mixValue = QType::Cast($mixValue, QType::Integer))) {
+							$this->blnModified = true;
+							$this->intButtonMode = $mixValue;
+						}
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
 						throw $objExc;
@@ -405,6 +425,7 @@
 						else {
 							$this->strMaxHeight = QType::Cast($mixValue, QType::String);
 						}
+						$this->blnModified = true;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
 						throw $objExc;

--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -1688,6 +1688,7 @@
 		 */
 		public function MarkAsWrapperModified() {
 			$this->blnWrapperModified = true;
+			$this->blnModified = true;
 		}
 
 		/**
@@ -1807,7 +1808,6 @@
 			return false;
 		}
 
-
 		/////////////////////////
 		// Public Properties: GET
 		/////////////////////////
@@ -1920,13 +1920,14 @@
 		 * @throws Exception|QInvalidCastException
 		 */
 		public function __set($strName, $mixValue) {
-			$this->blnModified = true;
-
 			switch ($strName) {
 				// APPEARANCE
 				case "BackColor":
 					try {
-						$this->strBackColor = QType::Cast($mixValue, QType::String);
+						if ($this->strBackColor !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strBackColor = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -1934,7 +1935,10 @@
 					}
 				case "BorderColor":
 					try {
-						$this->strBorderColor = QType::Cast($mixValue, QType::String);
+						if ($this->strBorderColor !== ($mixValue = QType::Cast($mixValue, QType::String))){
+							$this->blnModified = true;
+							$this->strBorderColor = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -1942,7 +1946,10 @@
 					}
 				case "BorderStyle":
 					try {
-						$this->strBorderStyle = QType::Cast($mixValue, QType::String);
+						if ($this->strBorderStyle !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strBorderStyle = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -1950,7 +1957,10 @@
 					}
 				case "BorderWidth":
 					try {
-						$this->strBorderWidth = QType::Cast($mixValue, QType::String);
+						if ($this->strBorderWidth !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strBorderWidth = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -1958,7 +1968,10 @@
 					}
 				case "CssClass":
 					try {
-						$this->strCssClass = QType::Cast($mixValue, QType::String);
+						if ($this->strCssClass !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strCssClass = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -1978,10 +1991,13 @@
 					}
 				case "DisplayStyle":
 					try {
-						$this->strDisplayStyle = QType::Cast($mixValue, QType::String);
-						if (($this->strDisplayStyle == QDisplayStyle::Block) ||
-							($this->strDisplayStyle == QDisplayStyle::Inline))
-							$this->strDisplayStyle = $this->strDisplayStyle;
+						if ($this->strDisplayStyle !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strDisplayStyle = $mixValue;
+							if ($this->strDisplayStyle != QDisplayStyle::None) {
+								$this->blnDisplay = true;
+							}
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -1989,7 +2005,10 @@
 					}
 				case "FontBold":
 					try {
-						$this->blnFontBold = QType::Cast($mixValue, QType::Boolean);
+						if ($this->blnFontBold !== ($mixValue = QType::Cast($mixValue, QType::Boolean))) {
+							$this->blnModified = true;
+							$this->blnFontBold = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -1997,7 +2016,10 @@
 					}
 				case "FontItalic":
 					try {
-						$this->blnFontItalic = QType::Cast($mixValue, QType::Boolean);
+						if ($this->blnFontItalic !== ($mixValue = QType::Cast($mixValue, QType::Boolean))) {
+							$this->blnModified = true;
+							$this->blnFontItalic = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2005,7 +2027,10 @@
 					}
 				case "FontNames":
 					try {
-						$this->strFontNames = QType::Cast($mixValue, QType::String);
+						if ($this->strFontNames !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strFontNames = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2013,7 +2038,10 @@
 					}
 				case "FontOverline":
 					try {
-						$this->blnFontOverline = QType::Cast($mixValue, QType::Boolean);
+						if ($this->blnFontOverline !== ($mixValue = QType::Cast($mixValue, QType::Boolean))) {
+							$this->blnModified = true;
+							$this->blnFontOverline = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2021,7 +2049,10 @@
 					}
 				case "FontSize":
 					try {
-						$this->strFontSize = QType::Cast($mixValue, QType::String);
+						if ($this->strFontSize !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strFontSize = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2029,7 +2060,10 @@
 					}
 				case "FontStrikeout":
 					try {
-						$this->blnFontStrikeout = QType::Cast($mixValue, QType::Boolean);
+						if ($this->blnFontStrikeout !== ($mixValue = QType::Cast($mixValue, QType::Boolean))) {
+							$this->blnModified = true;
+							$this->blnFontStrikeout = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2037,7 +2071,10 @@
 					}
 				case "FontUnderline":
 					try {
-						$this->blnFontUnderline = QType::Cast($mixValue, QType::Boolean);
+						if ($this->blnFontUnderline !== ($mixValue = QType::Cast($mixValue, QType::Boolean))) {
+							$this->blnModified = true;
+							$this->blnFontUnderline = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2045,7 +2082,10 @@
 					}
 				case "ForeColor":
 					try {
-						$this->strForeColor = QType::Cast($mixValue, QType::String);
+						if ($this->strForeColor !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strForeColor = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2053,9 +2093,12 @@
 					}
 				case "Opacity":
 					try {
-						$this->intOpacity = QType::Cast($mixValue, QType::Integer);
-						if (($this->intOpacity < 0) || ($this->intOpacity > 100))
-							throw new QCallerException('Opacity must be an integer value between 0 and 100');
+						if ($this->intOpacity !== ($mixValue = QType::Cast($mixValue, QType::Integer))) {
+							if (($this->intOpacity < 0) || ($this->intOpacity > 100))
+								throw new QCallerException('Opacity must be an integer value between 0 and 100');
+							$this->blnModified = true;
+							$this->intOpacity = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2065,7 +2108,10 @@
 				// BEHAVIOR
 				case "AccessKey":
 					try {
-						$this->strAccessKey = QType::Cast($mixValue, QType::String);
+						if ($this->strAccessKey !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strAccessKey = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2074,6 +2120,7 @@
 				case "CausesValidation":
 					try {
 						$this->mixCausesValidation = $mixValue;
+						// This would not need to cause a redraw
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2081,7 +2128,10 @@
 					}
 				case "Cursor":
 					try {
-						$this->strCursor = QType::Cast($mixValue, QType::String);
+						if ($this->strCursor !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strCursor = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2089,7 +2139,10 @@
 					}
 				case "Enabled":
 					try {
-						$this->blnEnabled = QType::Cast($mixValue, QType::Boolean);
+						if ($this->blnEnabled !== ($mixValue = QType::Cast($mixValue, QType::Boolean))) {
+							$this->blnModified = true;
+							$this->blnEnabled = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2105,7 +2158,10 @@
 					}
 				case "TabIndex":
 					try {
-						$this->intTabIndex = QType::Cast($mixValue, QType::Integer);
+						if ($this->intTabIndex !== ($mixValue = QType::Cast($mixValue, QType::Integer))) {
+							$this->blnModified = true;
+							$this->intTabIndex = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2113,7 +2169,10 @@
 					}
 				case "ToolTip":
 					try {
-						$this->strToolTip = QType::Cast($mixValue, QType::String);
+						if ($this->strToolTip !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strToolTip = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2121,7 +2180,10 @@
 					}
 				case "Visible":
 					try {
-						$this->blnVisible = QType::Cast($mixValue, QType::Boolean);
+						if ($this->blnVisible !== ($mixValue = QType::Cast($mixValue, QType::Boolean))) {
+							$this->blnModified = true;
+							$this->blnVisible = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2129,7 +2191,10 @@
 					}
 				case "PreferredRenderMethod":
 					try {
-						$this->strPreferredRenderMethod = QType::Cast($mixValue, QType::String);
+						if ($this->strPreferredRenderMethod !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strPreferredRenderMethod = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2139,7 +2204,10 @@
 				// LAYOUT
 				case "Height":
 					try {
-						$this->strHeight = QType::Cast($mixValue, QType::String);
+						if ($this->strHeight !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strHeight = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2147,7 +2215,10 @@
 					}
 				case "Width":
 					try {
-						$this->strWidth = QType::Cast($mixValue, QType::String);
+						if ($this->strWidth !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strWidth = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2155,7 +2226,10 @@
 					}
 				case "HtmlBefore":
 					try {
-						$this->strHtmlBefore = QType::Cast($mixValue, QType::String);
+						if ($this->strHtmlBefore !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strHtmlBefore = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2163,7 +2237,10 @@
 					}
 				case "HtmlAfter":
 					try {
-						$this->strHtmlAfter = QType::Cast($mixValue, QType::String);
+						if ($this->strHtmlAfter !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strHtmlAfter = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2171,7 +2248,10 @@
 					}
 				case "Instructions":
 					try {
-						$this->strInstructions = QType::Cast($mixValue, QType::String);
+						if ($this->strInstructions !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strInstructions = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2180,6 +2260,7 @@
 				case "Warning":
 					try {
 						$this->strWarning = QType::Cast($mixValue, QType::String);
+						$this->blnModified = true;	// always modify, since it will get reset on subsequent drawing
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2188,7 +2269,10 @@
 
 				case "Overflow":
 					try {
-						$this->strOverflow = QType::Cast($mixValue, QType::String);
+						if ($this->strOverflow !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strOverflow = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2233,6 +2317,7 @@
 
 				case "Moveable":
 					try {
+						$this->MarkAsWrapperModified();
 						if (QType::Cast($mixValue, QType::Boolean)) {
 							if (!$this->objDraggable) {
 								$this->objDraggable = new QDraggable($this);
@@ -2253,6 +2338,7 @@
 
 				case "Resizable":
 					try {
+						$this->MarkAsWrapperModified();
 						if (QType::Cast($mixValue, QType::Boolean)) {
 							if (!$this->objResizable) {
 								$this->objResizable = new QResizable($this);
@@ -2273,6 +2359,7 @@
 
 				case "Droppable":
 					try {
+						$this->MarkAsWrapperModified();
 						if (QType::Cast($mixValue, QType::Boolean)) {
 							if (!$this->objDroppable) {
 								$this->objDroppable = new QDroppable($this);
@@ -2294,7 +2381,10 @@
 				// MISC
 				case "Name":
 					try {
-						$this->strName = QType::Cast($mixValue, QType::String);
+						if ($this->strName !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strName = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2304,6 +2394,7 @@
 				case "ActionParameter":
 					try {
 						$this->mixActionParameter = ($mixValue instanceof QJsClosure) ? $mixValue : QType::Cast($mixValue, QType::String);
+						$this->blnModified = true;
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2336,6 +2427,8 @@
 						$objExc->IncrementOffset();
 						throw $objExc;
 					}
+
+				// CODEGEN
 				case "LinkedNode":
 					try {
 						$this->objLinkedNode = QType::Cast($mixValue, 'QQBaseNode');

--- a/includes/base_controls/QListBoxBase.class.php
+++ b/includes/base_controls/QListBoxBase.class.php
@@ -244,13 +244,14 @@
 		// Public Properties: SET
 		/////////////////////////
 		public function __set($strName, $mixValue) {
-			$this->blnModified = true;
-
 			switch ($strName) {
 				// APPEARANCE
 				case "Rows":
 					try {
-						$this->intRows = QType::Cast($mixValue, QType::Integer);
+						if ($this->intRows !== ($mixValue = QType::Cast($mixValue, QType::Integer))) {
+							$this->blnModified = true;
+							$this->intRows = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -276,7 +277,10 @@
 				// BEHAVIOR
 				case "SelectionMode":
 					try {
-						$this->strSelectionMode = QType::Cast($mixValue, QType::String);
+						if ($this->strSelectionMode !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strSelectionMode = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -285,6 +289,7 @@
 				
 				case "ItemStyle":
 					try {
+						$this->blnModified = true;
 						$this->objItemStyle = QType::Cast($mixValue, "QListItemStyle");
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();

--- a/includes/base_controls/QListControl.class.php
+++ b/includes/base_controls/QListControl.class.php
@@ -315,7 +315,6 @@
 		 * @throws Exception|QInvalidCastException
 		 */
 		public function __set($strName, $mixValue) {
-			$this->blnModified = true;
 			switch ($strName) {
 				case "SelectedIndex":
 					try {
@@ -324,6 +323,8 @@
 						$objExc->IncrementOffset();
 						throw $objExc;
 					}
+
+					$this->blnModified = true;
 
 					// Special Case
 					if ($mixValue == -1)
@@ -341,6 +342,7 @@
 					break;
 
 				case "SelectedName":
+					$this->blnModified = true;
 					foreach ($this->objItemsArray as $objItem)
 						if ($objItem->Name == $mixValue)
 							$objItem->Selected = true;
@@ -351,6 +353,7 @@
 
 				case "SelectedValue":
 				case "Value": // most common situation
+					$this->blnModified = true;
 					foreach ($this->objItemsArray as $objItem)
 						if (!$mixValue) {
 							if ($mixValue === null || $mixValue === '') {
@@ -382,6 +385,7 @@
 						$objExc->IncrementOffset();
 						throw $objExc;
 					}
+					$this->blnModified = true;
 					foreach ($this->objItemsArray as $objItem) {
 						$objItem->Selected = false;
 						foreach ($mixValue as $mixName) {
@@ -401,6 +405,7 @@
 						$objExc->IncrementOffset();
 						throw $objExc;
 					}
+					$this->blnModified = true;
 					foreach ($this->objItemsArray as $objItem) {
 						$objItem->Selected = false;
 						$mixCurVal = $objItem->Value;

--- a/includes/base_controls/QTextBoxBase.class.php
+++ b/includes/base_controls/QTextBoxBase.class.php
@@ -489,15 +489,14 @@
 						$objExc->IncrementOffset();
 						throw $objExc;
 					}
-			}
 
-			$this->blnModified = true;
-
-			switch ($strName) {
 				// APPEARANCE
 				case "Columns":
 					try {
-						$this->intColumns = QType::Cast($mixValue, QType::Integer);
+						if ($this->intColumns !== ($mixValue = QType::Cast($mixValue, QType::Integer))) {
+							$this->blnModified = true;
+							$this->intColumns = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -505,16 +504,10 @@
 					}
 				case "Format":
 					try {
-						$this->strFormat = QType::Cast($mixValue, QType::String);
-						break;
-					} catch (QInvalidCastException $objExc) {
-						$objExc->IncrementOffset();
-						throw $objExc;
-					}
-				case "Text":
-				case "Value":
-					try {
-						$this->strText = QType::Cast($mixValue, QType::String);
+						if ($this->strFormat !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strFormat = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -522,6 +515,7 @@
 					}
 				case "LabelForRequired":
 					try {
+						// no redraw needed
 						$this->strLabelForRequired = QType::Cast($mixValue, QType::String);
 						break;
 					} catch (QInvalidCastException $objExc) {
@@ -570,7 +564,10 @@
 					}
 				case "Placeholder":
 					try {
-						$this->strPlaceholder = QType::Cast($mixValue, QType::String);
+						if ($this->strPlaceholder !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strPlaceholder = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -592,7 +589,10 @@
 					}
 				case "MaxLength":
 					try {
-						$this->intMaxLength = QType::Cast($mixValue, QType::Integer);
+						if ($this->intMaxLength !== ($mixValue = QType::Cast($mixValue, QType::Integer))) {
+							$this->blnModified = true;
+							$this->intMaxLength = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -600,7 +600,10 @@
 					}
 				case "MinLength":
 					try {
-						$this->intMinLength = QType::Cast($mixValue, QType::Integer);
+						if ($this->intMinLength !== ($mixValue = QType::Cast($mixValue, QType::Integer))) {
+							$this->blnModified = true;
+							$this->intMinLength = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -608,7 +611,10 @@
 					}
 				case "ReadOnly":
 					try {
-						$this->blnReadOnly = QType::Cast($mixValue, QType::Boolean);
+						if ($this->blnReadOnly !== ($mixValue = QType::Cast($mixValue, QType::Boolean))) {
+							$this->blnModified = true;
+							$this->blnReadOnly = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -616,7 +622,10 @@
 					}
 				case "Rows":
 					try {
-						$this->intRows = QType::Cast($mixValue, QType::Integer);
+						if ($this->intRows !== ($mixValue = QType::Cast($mixValue, QType::Integer))) {
+							$this->blnModified = true;
+							$this->intRows = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -624,7 +633,10 @@
 					}
 				case "TextMode":
 					try {
-						$this->strTextMode = QType::Cast($mixValue, QType::String);
+						if ($this->strTextMode !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->blnModified = true;
+							$this->strTextMode = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -642,14 +654,17 @@
 				// LAYOUT
 				case "Wrap":
 					try {
-						$this->blnWrap = QType::Cast($mixValue, QType::Boolean);
+						if ($this->blnWrap !== ($mixValue = QType::Cast($mixValue, QType::Boolean))) {
+							$this->blnModified = true;
+							$this->blnWrap = $mixValue;
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
 						throw $objExc;
 					}
 					
-				// FILTERING and VALIDATING
+				// FILTERING and VALIDATING, no redraw needed
 				case "AutoTrim":
 					try {
 						$this->blnAutoTrim = QType::Cast($mixValue, QType::Boolean);


### PR DESCRIPTION
Improving performance by eliminating unnecessary redraws. Makes sure that a value has changed before setting blnModified. This isn't a complete fix for all controls, but hits the base controls and the most common ones. Others can continue the work.
