### PR TITLE
bugfix-php72

### DIFF
--- a/includes/base_controls/QListItemManager.trait.php
+++ b/includes/base_controls/QListItemManager.trait.php
@@ -28,7 +28,11 @@
 		 */
 		public function AddListItem(QListItemBase $objListItem) {
 			if ($strControlId = $this->GetId()) {
-				$objListItem->SetId($strControlId . '_' . count($this->objListItemArray));	// auto assign the id based on parent id
+				$num = 0;
+				if ($this->objListItemArray) {
+					$num = count($this->objListItemArray);
+				}
+				$objListItem->SetId($strControlId . '_' . $num);	// auto assign the id based on parent id
 				$objListItem->Reindex();
 			}
 			$this->objListItemArray[] = $objListItem;

--- a/includes/codegen/QDatabaseCodeGen.class.php
+++ b/includes/codegen/QDatabaseCodeGen.class.php
@@ -672,6 +672,23 @@
 					}
 				}
 			}
+
+			// Make sure lone primary key columns are marked as unique
+			$objKeyColumn = null;
+			foreach ($objColumnArray as $objColumn) {
+				if ($objColumn->PrimaryKey) {
+					if ($objKeyColumn === null) {
+						$objKeyColumn = $objColumn;
+					}
+					else {
+						$objKeyColumn = false; // multiple key columns
+					}
+				}
+			}
+			if ($objKeyColumn) {
+				$objKeyColumn->Unique = true;
+			}
+
 			$objManyToManyReferenceArray[0]->ColumnArray = $objColumnArray;
 			$objManyToManyReferenceArray[1]->ColumnArray = $objColumnArray;
 
@@ -761,7 +778,9 @@
 			$objTypeTable->TokenArray = $strTokenArray;
 			$objTypeTable->ExtraFieldNamesArray = $strExtraFields;
 			$objTypeTable->ExtraPropertyArray = $strExtraPropertyArray;
-			$objTypeTable->KeyColumn = $this->AnalyzeTableColumn ($objFieldArray[0], $objTypeTable);
+			$objColumn = $this->AnalyzeTableColumn ($objFieldArray[0], $objTypeTable);
+			$objColumn->Unique = true;
+			$objTypeTable->KeyColumn = $objColumn;
 		}
 
 		protected function AnalyzeTable(QSqlTable $objTable) {
@@ -785,6 +804,22 @@
 				}
 			}
 			$objTable->ColumnArray = $objColumnArray;
+
+			// Make sure lone primary key columns are marked as unique
+			$objKeyColumn = null;
+			foreach ($objColumnArray as $objColumn) {
+				if ($objColumn->PrimaryKey) {
+					if ($objKeyColumn === null) {
+						$objKeyColumn = $objColumn;
+					}
+					else {
+						$objKeyColumn = false; // multiple key columns
+					}
+				}
+			}
+			if ($objKeyColumn) {
+				$objKeyColumn->Unique = true;
+			}
 
 
 
@@ -1093,8 +1128,8 @@
 			$objColumn->NotNull = $objField->NotNull;
 			$objColumn->Identity = $objField->Identity;
 			$objColumn->Unique = $objField->Unique;
-			if (($objField->PrimaryKey) && $objTable && (count($objTable->PrimaryKeyColumnArray) == 1))
-				$objColumn->Unique = true;
+
+
 			$objColumn->Timestamp = $objField->Timestamp;
 
 			$objColumn->VariableName = $this->ModelColumnVariableName($objColumn);

--- a/includes/framework/QDateTime.class.php
+++ b/includes/framework/QDateTime.class.php
@@ -506,7 +506,7 @@
 		 * @param int|null $intSecond
 		 * @return QDateTime
 		 */
-		public function setTime($mixValue, $intMinute = null, $intSecond = null) {
+		public function setTime($mixValue, $intMinute = null, $intSecond = null, $intMicroSeconds = null) {
 			if ($mixValue instanceof QDateTime) {
 				if ($mixValue->IsTimeNull()) {
 					$this->blnTimeNull = true;
@@ -527,7 +527,11 @@
 			}
 			// If HOUR or MINUTE is NULL...
 			if (is_null($intHour) || is_null($intMinute)) {
-				parent::setTime($intHour, $intMinute, $intSecond);
+				if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+					parent::setTime($intHour, $intMinute, $intSecond, $intMicroSeconds);
+				} else {
+					parent::setTime($intHour, $intMinute, $intSecond);
+				}
 				$this->blnTimeNull = true;
 				$this->ReinforceNullProperties();
 				return $this;
@@ -548,7 +552,11 @@
 				// will continue and set again to make sure, because boundary crossing will change the time
 			}*/
 
-			parent::setTime($intHour, $intMinute, $intSecond);
+			if (version_compare(PHP_VERSION, '7.2.0', '>=')) {
+				parent::setTime($intHour, $intMinute, $intSecond, $intMicroSeconds);
+			} else {
+				parent::setTime($intHour, $intMinute, $intSecond);
+			}
 
 			return $this;
 		}


### PR DESCRIPTION
PHP 7.2 is now in the nightly build and is causing Travis to fail. The problems are two things:

count() does not handle a null value as an array. This uncovered a problem in code generation in the column analyzer.

Also, DateTime::setTime added a microsecond parameter.