### PR TITLE
bugfix-CodeGenReferenceSet

### DIFF
--- a/includes/codegen/templates/db_orm/class_gen/property_set.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/property_set.tpl.php
@@ -29,8 +29,7 @@
 
 					 */
 					if (is_null($mixValue)) {
-						$this-><?= $objColumn->VariableName ?> = null;
-						$this-><?= $objColumn->Reference->VariableName ?> = null;
+						$this->set<?= $objColumn->PropertyName ?>(null);
 						return null;
 					} else {
 						// Make sure $mixValue actually is a <?= $objColumn->Reference->VariableType ?> object
@@ -46,8 +45,8 @@
 							throw new QCallerException('Unable to set an unsaved <?= $objColumn->Reference->PropertyName ?> for this <?= $objTable->ClassName ?>');
 
 						// Update Local Member Variables
+						$this->set<?= $objColumn->PropertyName ?>($mixValue-><?= $objCodeGen->TableArray[strtolower($objColumn->Reference->Table)]->ColumnArray[strtolower($objColumn->Reference->Column)]->PropertyName ?>);
 						$this-><?= $objColumn->Reference->VariableName ?> = $mixValue;
-						$this-><?= $objColumn->VariableName ?> = $mixValue-><?= $objCodeGen->TableArray[strtolower($objColumn->Reference->Table)]->ColumnArray[strtolower($objColumn->Reference->Column)]->PropertyName ?>;
 
 						// Return $mixValue
 						return $mixValue;

--- a/includes/framework/QCryptography.class.php
+++ b/includes/framework/QCryptography.class.php
@@ -23,7 +23,7 @@ class QCryptographyException extends QCallerException {
  *    cannot be seen by a user, then when the instance gets unserialized, the IV will be restored automatically.
  * 	  Storing the instance in a QApplication or global variable will not work, since these things are reinitialized every
  *    time PHP starts up, and you will get a different IV at that time. If you do not correctly
- * 	  restore the IV that was used to Encrypt, that you will not be able to Decrypt.
+ * 	  restore the IV that was used to Encrypt, then you will not be able to Decrypt.
  *
  * 2) Pass a value to $strIvHashKey in the constructor, and the initialization vector will be appended to the resulting encrypted data.
  *    This hash key SHOULD be a static value that is part of your app and must be passed to the constructor of any instance of

--- a/includes/tests/qcubed-unit/BasicOrmTest.php
+++ b/includes/tests/qcubed-unit/BasicOrmTest.php
@@ -474,5 +474,23 @@ class BasicOrmTests extends QUnitTestCaseBase {
 		$objMilestone->Reload();
 		$this->assertEquals(1, $objMilestone->Id, "Identity should reset to original value after a reload");
 	}
+
+	public function testSetReference() {
+		$milestone1 = Milestone::Load(1);
+		$intProjectId = $milestone1->ProjectId;
+
+		$project4 = Project::Load(4);
+
+		$milestone1->Project = $project4;
+		$milestone1->Save();
+
+		$milestone1 = Milestone::Load(1);
+		$this->assertEquals(4, $milestone1->Project->Id);
+
+		// Restore state of database
+		$milestone1->ProjectId = $intProjectId;
+		$milestone1->Save();
+		$this->assertEquals($intProjectId, $milestone1->Project->Id);
+	}
 }
 


### PR DESCRIPTION
Fixing a regression problem from recently added setters and getters. I needed to make sure references are set in such a way as to be sure to update related ids, and also set the related object after setting the id, since setting the id will make the related object null.