### PR TITLE
Ensure that we implement expiration timeout to existing cache providers

### DIFF
--- a/includes/framework/QAbstractCacheProvider.class.php
+++ b/includes/framework/QAbstractCacheProvider.class.php
@@ -15,7 +15,7 @@
 		 * Set the object into the cache with the given key
 		 *
 		 * @param string  $strKey        the key to use for the object
-		 * @param object  $objValue      the object to put in the cache
+		 * @param mixed   $objValue      the object to put in the cache
 		 * @param integer $intExpiration Number of seconds after which the value has to expire
 		 *
 		 * @return void

--- a/includes/framework/QAbstractCacheProvider.class.php
+++ b/includes/framework/QAbstractCacheProvider.class.php
@@ -16,7 +16,7 @@
 		 *
 		 * @param string  $strKey        the key to use for the object
 		 * @param object  $objValue      the object to put in the cache
-		 * @param integer $intExpiration Duration for which the cache has to live
+		 * @param integer $intExpiration Number of seconds after which the value has to expire
 		 *
 		 * @return void
 		 */

--- a/includes/framework/QAbstractCacheProvider.class.php
+++ b/includes/framework/QAbstractCacheProvider.class.php
@@ -13,11 +13,14 @@
 
 		/**
 		 * Set the object into the cache with the given key
-		 * @param string $strKey the key to use for the object
-		 * @param object $objValue the object to put in the cache
+		 *
+		 * @param string  $strKey        the key to use for the object
+		 * @param object  $objValue      the object to put in the cache
+		 * @param integer $intExpiration Duration for which the cache has to live
+		 *
 		 * @return void
 		 */
-		abstract public function Set($strKey, $objValue);
+		abstract public function Set($strKey, $objValue, $intExpiration);
 
 		/**
 		 * Delete the object that has the given key from the cache

--- a/includes/framework/QAbstractCacheProvider.class.php
+++ b/includes/framework/QAbstractCacheProvider.class.php
@@ -20,7 +20,7 @@
 		 *
 		 * @return void
 		 */
-		abstract public function Set($strKey, $objValue, $intExpiration);
+		abstract public function Set($strKey, $objValue, $intExpiration = null);
 
 		/**
 		 * Delete the object that has the given key from the cache

--- a/includes/framework/QCacheProviderAPC.class.php
+++ b/includes/framework/QCacheProviderAPC.class.php
@@ -29,7 +29,7 @@
 		 * @return void
 		 */
 		public function Set($strKey, $objValue, $intExpireAfterSeconds = null) {
-			if($intExpireAfterSeconds) {
+			if(!is_null($intExpireAfterSeconds)) {
 				apc_store ($strKey, $objValue, (int)$intExpireAfterSeconds);
 			} else {
 				apc_store($strKey, $objValue, static::$ttl);

--- a/includes/framework/QCacheProviderAPC.class.php
+++ b/includes/framework/QCacheProviderAPC.class.php
@@ -21,13 +21,19 @@
 
 		/**
 		 * Set the object into the cache with the given key
-		 * @param string $strKey the key to use for the object
-		 * @param object $objValue the object to put in the cache
+		 *
+		 * @param string $strKey                the key to use for the object
+		 * @param object $objValue              the object to put in the cache
+		 * @param int    $intExpireAfterSeconds Number of seconds after which the object has to expire
+		 *
 		 * @return void
 		 */
-		public function Set($strKey, $objValue) {
-			apc_store ($strKey, $objValue, static::$ttl);
-
+		public function Set($strKey, $objValue, $intExpireAfterSeconds = null) {
+			if($intExpireAfterSeconds) {
+				apc_store ($strKey, $objValue, (int)$intExpireAfterSeconds);
+			} else {
+				apc_store($strKey, $objValue, static::$ttl);
+			}
 		}
 
 		/**

--- a/includes/framework/QCacheProviderLocalMemory.class.php
+++ b/includes/framework/QCacheProviderLocalMemory.class.php
@@ -45,7 +45,7 @@
 				}
 
 				if (isset($objToReturn['value']) && is_object($objToReturn['value'])) {
-					$objToReturn = clone $objToReturn;
+					$objToReturn['value'] = clone $objToReturn['value'];
 				}
 
 				return $objToReturn['value'];

--- a/includes/framework/QCacheProviderLocalMemory.class.php
+++ b/includes/framework/QCacheProviderLocalMemory.class.php
@@ -28,7 +28,7 @@
 		/**
 		 * Get the object that has the given key from the cache
 		 * @param string $strKey the key of the object in the cache
-		 * @return object
+		 * @return object|bool
 		 */
 		public function Get($strKey) {
 			if (array_key_exists($strKey, $this->arrLocalCache)) {
@@ -36,21 +36,33 @@
 				// not a pointer to the stored object
 				// to prevent it's modification by user code.
 				$objToReturn = $this->arrLocalCache[$strKey];
-				if ($objToReturn && is_object($objToReturn)) {
+				if($objToReturn['timeToExpire'] != 0) {
+					// Time to expire was set. See if it should be expired
+					if($objToReturn['timeToExpire'] < time()) {
+						$this->Delete($strKey);
+						return false;
+					}
+				}
+
+				if (isset($objToReturn['value']) && is_object($objToReturn['value'])) {
 					$objToReturn = clone $objToReturn;
 				}
-				return $objToReturn;
+
+				return $objToReturn['value'];
 			}
 			return false;
 		}
 
 		/**
 		 * Set the object into the cache with the given key
-		 * @param string $strKey the key to use for the object
-		 * @param object $objValue the object to put in the cache
+		 *
+		 * @param string $strKey                    the key to use for the object
+		 * @param object $objValue                  the object to put in the cache
+		 * @param int    $intExpirationAfterSeconds Number of seconds after which the key has to expire
+		 *
 		 * @return void
 		 */
-		public function Set($strKey, $objValue) {
+		public function Set($strKey, $objValue, $intExpirationAfterSeconds = null) {
 			// Note the clone statement - it is important to store a copy,
 			// not a pointer to the user object
 			// to prevent it's modification by user code.
@@ -58,7 +70,10 @@
 			if ($objToSet && is_object($objToSet)) {
 				$objToSet = clone $objToSet;
 			}
-			$this->arrLocalCache[$strKey] = $objToSet;
+			$this->arrLocalCache[$strKey] = array (
+				'timeToExpire' => $intExpirationAfterSeconds ? (time() + QType::Cast($intExpirationAfterSeconds, QType::Integer)) : 0,
+				'value' => $objToSet
+			);
 		}
 
 		/**

--- a/includes/framework/QCacheProviderMemcache.class.php
+++ b/includes/framework/QCacheProviderMemcache.class.php
@@ -39,12 +39,15 @@
 
 		/**
 		 * Set the object into the cache with the given key
-		 * @param string $strKey the key to use for the object
-		 * @param object $objValue the object to put in the cache
+		 *
+		 * @param string $strKey                the key to use for the object
+		 * @param object $objValue              the object to put in the cache
+		 * @param null   $intExpireAfterSeconds Number of seconds after which the key will be expired
+		 *
 		 * @return void
 		 */
-		public function Set($strKey, $objValue) {
-			$this->objMemcache->set($strKey, $objValue);
+		public function Set($strKey, $objValue, $intExpireAfterSeconds = null) {
+			$this->objMemcache->set($strKey, $objValue, (int)$intExpireAfterSeconds);
 		}
 
 		/**

--- a/includes/framework/QCacheProviderNoCache.class.php
+++ b/includes/framework/QCacheProviderNoCache.class.php
@@ -8,26 +8,34 @@
 	class QCacheProviderNoCache extends QAbstractCacheProvider {
 		/**
 		 * Get the object that has the given key from the cache
+		 *
 		 * @param string $strKey the key of the object in the cache
-		 * @return object
+		 *
+		 * @return bool Always return false
 		 */
 		public function Get($strKey) {
+			// We are not saving anything. Hence, we return null
 			return false;
 		}
 
 		/**
 		 * Set the object into the cache with the given key
-		 * @param string $strKey the key to use for the object
-		 * @param object $objValue the object to put in the cache
+		 *
+		 * @param string $strKey                the key to use for the object
+		 * @param object $objValue              the object to put in the cache
+		 * @param int    $intExpireAfterSeconds Number of seconds after which the object will expire
+		 *
 		 * @return void
 		 */
-		public function Set($strKey, $objValue) {
+		public function Set($strKey, $objValue, $intExpireAfterSeconds) {
 			// do nothing
 		}
 
 		/**
 		 * Delete the object that has the given key from the cache
+		 *
 		 * @param string $strKey the key of the object in the cache
+		 *
 		 * @return void
 		 */
 		public function Delete($strKey) {
@@ -36,6 +44,7 @@
 
 		/**
 		 * Invalidate all the objects in the cache
+		 *
 		 * @return void
 		 */
 		public function DeleteAll() {

--- a/includes/framework/QCacheProviderNoCache.class.php
+++ b/includes/framework/QCacheProviderNoCache.class.php
@@ -27,7 +27,7 @@
 		 *
 		 * @return void
 		 */
-		public function Set($strKey, $objValue, $intExpireAfterSeconds) {
+		public function Set($strKey, $objValue, $intExpireAfterSeconds = null) {
 			// do nothing
 		}
 

--- a/includes/framework/QDatabaseBase.class.php
+++ b/includes/framework/QDatabaseBase.class.php
@@ -27,14 +27,21 @@
 		protected $objValue;
 
 		/**
+		 * @var null|int Time after which the object is to be invalidated/expired
+		 */
+		protected $intExpirationTime = null;
+
+		/**
 		 * Construct the new QCacheSetAction object.
 		 *
-		 * @param string $strKey   the key to use for the object
-		 * @param object $objValue the object to put in the cache
+		 * @param string   $strKey            the key to use for the object
+		 * @param object   $objValue          the object to put in the cache
+		 * @param null|int $intExpirationTime Number of seconds after which the value has to expire
 		 */
-		public function __construct($strKey, $objValue) {
+		public function __construct($strKey, $objValue, $intExpirationTime = null) {
 			$this->strKey = $strKey;
 			$this->objValue = $objValue;
+			$this->intExpirationTime = (int)$intExpirationTime;
 		}
 
 		/**
@@ -42,7 +49,7 @@
 		 * @param QAbstractCacheProvider $objCache The cache object to apply this action to.
 		 */
 		public function Execute(QAbstractCacheProvider $objCache) {
-			$objCache->Set($this->strKey, $this->objValue);
+			$objCache->Set($this->strKey, $this->objValue, $this->intExpirationTime);
 		}
 	}
 	/**
@@ -147,12 +154,12 @@
 			return false;
 		}
 
-		public function Set($strKey, $objValue) {
+		public function Set($strKey, $objValue, $intExpirationTime) {
 			$this->arrLocalCacheAdditions[$strKey] = $objValue;
 			if (isset($this->arrLocalCacheRemovals[$strKey])) {
 				unset($this->arrLocalCacheRemovals[$strKey]);
 			}
-			$this->objCacheActionQueue[] = new QCacheSetAction($strKey, $objValue);
+			$this->objCacheActionQueue[] = new QCacheSetAction($strKey, $objValue, $intExpirationTime);
 		}
 
 		public function Delete($strKey) {

--- a/includes/framework/QDatabaseBase.class.php
+++ b/includes/framework/QDatabaseBase.class.php
@@ -154,7 +154,7 @@
 			return false;
 		}
 
-		public function Set($strKey, $objValue, $intExpirationTime) {
+		public function Set($strKey, $objValue, $intExpirationTime = null) {
 			$this->arrLocalCacheAdditions[$strKey] = $objValue;
 			if (isset($this->arrLocalCacheRemovals[$strKey])) {
 				unset($this->arrLocalCacheRemovals[$strKey]);

--- a/includes/framework/QMultiLevelCacheProvider.class.php
+++ b/includes/framework/QMultiLevelCacheProvider.class.php
@@ -51,13 +51,16 @@
 
 		/**
 		 * Set the object into the cache with the given key
-		 * @param string $strKey the key to use for the object
+		 *
+		 * @param string $strKey   the key to use for the object
 		 * @param object $objValue the object to put in the cache
+		 * @param int    $intExpireAfterSeconds Number of seconds after which the value will expire
+		 *
 		 * @return void
 		 */
-		public function Set($strKey, $objValue) {
+		public function Set($strKey, $objValue, $intExpireAfterSeconds) {
 			foreach ($this->arrCacheProviders as $objCacheProvider) {
-				$objCacheProvider->Set($strKey, $objValue);
+				$objCacheProvider->Set($strKey, $objValue, $intExpireAfterSeconds);
 			}
 		}
 

--- a/includes/tests/qcubed-unit/CacheTest.php
+++ b/includes/tests/qcubed-unit/CacheTest.php
@@ -332,7 +332,6 @@ class CacheTests extends QUnitTestCaseBase {
 		$this->assertNull ($targetPerson->_ProjectAsManager, "Person 12 does not have a project.");
 				
 		//TODO: Conditional Array Expansion, requires API change
-		
 	}
 
 	// Test Expiry of cache after fixed time (test for auto-expiration of cache)

--- a/includes/tests/qcubed-unit/CacheTest.php
+++ b/includes/tests/qcubed-unit/CacheTest.php
@@ -335,4 +335,25 @@ class CacheTests extends QUnitTestCaseBase {
 		
 	}
 
+	// Test Expiry of cache after fixed time (test for auto-expiration of cache)
+	public function testTransactionWithCacheSaveCommit() {
+		// establish a cache object we can work with
+		$objCacheProvider = QApplication::$objCacheProvider;
+		QApplication::$objCacheProvider = new QCacheProviderLocalMemoryTest(array());
+		// cache is empty now
+
+		// Set something in the cache to expire after 5 seconds
+		QApplication::$objCacheProvider->Set('testString', 'cached string abcd', 5);
+
+		// Fetching immediately
+		$this->assertEquals('cached string abcd', QApplication::$objCacheProvider->Get('testString'), "Value fetched from cache does not match the value set into the cache.");
+
+		// Wait for 6 to ensure that the object has expired
+		sleep(6);
+
+		$this->assertEquals(false, QApplication::$objCacheProvider->Get('testString'), "Value set into cache for automatic expiration did not expire after specified time");
+
+		// restore the actual cache object
+		QApplication::$objCacheProvider = $objCacheProvider;
+	}
 }

--- a/includes/tests/qcubed-unit/QDatabaseTest.php
+++ b/includes/tests/qcubed-unit/QDatabaseTest.php
@@ -117,8 +117,8 @@ class QDatabaseTests extends QUnitTestCaseBase {
 			// temporary cache is throwed out. the empty application cache is restored.
 		}
 		$this->assertEquals(1, count(QApplication::$objCacheProvider->arrLocalCache), "Object is not dropped from a cache because of the transaction roll back.");
-		foreach (QApplication::$objCacheProvider->arrLocalCache as $objPerson) {
-			$this->assertEquals($strPerson1_FirstName, $objPerson->FirstName, "Object is not modified in a cache because of the transaction roll back.");
+		foreach (QApplication::$objCacheProvider->arrLocalCache as $objPersonCacheArray) {
+			$this->assertEquals($strPerson1_FirstName, $objPersonCacheArray['value']->FirstName, "Object is not modified in a cache because of the transaction roll back.");
 		}
 
 		// restore the actual cache object

--- a/includes/tests/qcubed-unit/QDatabaseTest.php
+++ b/includes/tests/qcubed-unit/QDatabaseTest.php
@@ -202,8 +202,8 @@ class QDatabaseTests extends QUnitTestCaseBase {
 		// new person value is placed in the application cache
 		
 		$this->assertEquals(1, count(QApplication::$objCacheProvider->arrLocalCache), "Object is not dropped from a cache because of the transaction commit.");
-		foreach (QApplication::$objCacheProvider->arrLocalCache as $objPerson) {
-			$this->assertEquals("New value 1", $objPerson->FirstName, "Object is modified in a cache because of the transaction commit.");
+		foreach (QApplication::$objCacheProvider->arrLocalCache as $objPersonCacheArray) {
+			$this->assertEquals("New value 1", $objPersonCacheArray['value']->FirstName, "Object is modified in a cache because of the transaction commit.");
 		}
 		
 		// Restore the original value to not break other tests

--- a/includes/tests/qcubed-unit/QDatabaseTest.php
+++ b/includes/tests/qcubed-unit/QDatabaseTest.php
@@ -156,8 +156,8 @@ class QDatabaseTests extends QUnitTestCaseBase {
 		// new person value is placed in the application cache
 		
 		$this->assertEquals(1, count(QApplication::$objCacheProvider->arrLocalCache), "Object is added to a cache because of the transaction commit.");
-		foreach (QApplication::$objCacheProvider->arrLocalCache as $objPerson) {
-			$this->assertEquals("New value 1", $objPerson->FirstName, "Object is modified in a cache because of the transaction commit.");
+		foreach (QApplication::$objCacheProvider->arrLocalCache as $objPersonCacheArray) {
+			$this->assertEquals("New value 1", $objPersonCacheArray['value']->FirstName, "Object is modified in a cache because of the transaction commit.");
 		}
 		
 		// Restore the original value to not break other tests


### PR DESCRIPTION
Ensure that we implement expiration timeout to **existing** caches. 

This is quite useful and lays out the ground-work for implementing Redis as a cache provider.