### PR TITLE
Basic Redis Cache provider built

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ addons:
     packages:
       - redis-server
 
+services:
+  - redis-server
+
 env:
     - DB=mysql
     - DB=pgsql POSTGRESQL_VERSION=9.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ install:
     - composer install
     - composer require "predis/predis:^1.1"
 
+addons:
+  apt:
+    packages:
+      - redis-server
+
 env:
     - DB=mysql
     - DB=pgsql POSTGRESQL_VERSION=9.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ php:
 
 install:
     - composer install
+    - composer require "predis/predis:^1.1"
 
 env:
     - DB=mysql

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
   },
   "suggest": {
     "ezyang/htmlpurifier": "dev-master",
-    "fortawesome/font-awesome": "^4.6"
+    "fortawesome/font-awesome": "^4.6",
+    "predis/predis": "^1"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "suggest": {
     "ezyang/htmlpurifier": "dev-master",
     "fortawesome/font-awesome": "^4.6",
-    "predis/predis": "^1"
+    "predis/predis": "^1.1"
   },
   "autoload": {
     "psr-4": {

--- a/docs/Caching/README.md
+++ b/docs/Caching/README.md
@@ -1,0 +1,7 @@
+# Caching in QCubed
+
+QCubed allows you to cache various types of data at different levels. Caching, as of now is divided into two different parts: 
+
+1. File based caching (**QCache**): Uses the server's local file system to store cached data.
+2. Provider based caching (**QCacheProvider\* Classes**) - Adaptable Caching based on third party libraries (Memcached, Redis etc.)
+

--- a/docs/Caching/Redis.md
+++ b/docs/Caching/Redis.md
@@ -5,7 +5,7 @@ Redis is a key-value style data-structures store. The key length as well as the 
  Performance of Redis depends on whether it is running in persistent mode (saving data to disk) or in-memory mode (all contents are within the specified memory limits). Default configurations run in persistent mode. However, depending on use-case (data structures stored, amount of data stored etc.), performance of Redis can be between "a little slower" to "just a little faster" than memcached. However, implementation of Redis is way more powerful because of the data-structures implementation.
  
  ## Usage of Predis library
- [Predis](https://github.com/nrk/predis) is the most powerful and popular client library for Redis written in PHP. QCubed uses Predis for using Redis as cache. QCubed's cache system cannot use Redis unless you install Predis. It is also a suggested package in our `composer.json`.
+ [Predis](https://github.com/nrk/predis) is a popular (and widely regarded one of the most powerful) library for Redis written in PHP. QCubed uses Predis for using Redis as cache. QCubed's cache system cannot use Redis unless you install Predis. It is also a suggested package in our `composer.json`.
  
  You can simply use `composer require "predis/predis":"^1"` to install. Please see the [project page](https://github.com/nrk/predis) for installation instructions.
  

--- a/docs/Caching/Redis.md
+++ b/docs/Caching/Redis.md
@@ -26,8 +26,69 @@ define ('CACHE_PROVIDER_OPTIONS', serialize(
 
 The configuration **must always contain the 'parameters' and 'options' keys**. These go in the constructor of `Predis\Client`. Please see the [project page](https://github.com/nrk/predis) if you want to use custom connection options for your redis-server installation.
 
+### Expiration of keys
+Keys can be set to auto-expire in Redis (like in other cache service providers). However, there is a special behavior for Redis cache controlled by a named constant - `_REDIS_CACHE_PROVIDER_DEFAULT_TTL_`. We will first tell you why we treat Redis cache differently.
+
+Of all cache providers, Redis is the only one which **persists its data on disk**. *LocalMemory* provider would invalidate caches after request ends. *NoCache* invalidates caches immediately. *APC* would invalidate after webserver/fpm service restart. *Memcache* would invalidate after memcache service or server restarts. 
+
+By default, Redis does not exhibit such a behavior. All keys will go on getting saved until they are manually deleted or are evicted because of a expire time applied to the key when setting the value. Since caches should be automatically managed and should use limited resources, it is important that they free resources from time to time. Each cache provider has these limitations in place while a server-reboot is the final solution to a error or resource-overusage for them. The only method Redis' default installation gives us for automatically managing resource usage (in this case, storage) is setting an expire-time on keys using which Redis automatically frees up memory/storage. The `_REDIS_CACHE_PROVIDER_DEFAULT_TTL_` named constant allows us to control Redis' storage requirement. 
+
+When this value is set, each cache key set into Redis by using QCubed's built in Cache-Provider mechanism gets a default expiration time. The expiration time is equal to the number of seconds this value is defined as. 
+  
+**Example**: 
+
+You have defined the value in `configuration.inc.php` as:
+
+```php
+define('_REDIS_CACHE_PROVIDER_DEFAULT_TTL_', 7200);
+```
+
+Later, when you save a value into Redis cache using:
+
+```php
+QApplication::$objCacheProvider->Set('someKey1', $strSomeValue, 60);
+```
+
+Then *someKey1* will automatically be removed from cache in **60 seconds**. This is because you passed the third argument into the method as 60, which overrides the defaults.
+
+However, if you were to set another key using: 
+
+```php
+QApplication::$objCacheProvider->Set('someKey2', $strSomeValue);
+```
+
+Then *someKey2* will be removed from the cache in 2 hours (7200 seconds).
+
+---
+If you set the value to 0 (or anything else which is evaluated as 0 by PHP), like: 
+
+```php
+define('_REDIS_CACHE_PROVIDER_DEFAULT_TTL_', 7200);
+```
+
+This this statement: 
+```php
+QApplication::$objCacheProvider->Set('someKey3', $strSomeValue);
+```
+
+Will not set a default expiration time and the value corresponding to *someKey3* will stay in Redis cache untill you remove it.
+
+However, this statement: 
+
+```php
+QApplication::$objCacheProvider->Set('someKey4', $strSomeValue, 60);
+```
+
+would still make *someKey4* expire after 1 minute.
+
+
 ## Full power of Redis is available
  
- The `QApplication::$objCacheProvider` created for Redis Caching is a wrapper around `Predis\Client` instance and can take all commands like `sadd` and `sismember` (e.g. `QApplication::$objCacheProvider->sadd('keyS', [2,5,10])`). 
+ The `QApplication::$objCacheProvider` created for Redis Caching is a wrapper around `Predis\Client` instance and can take all commands like `sadd` and `sismember` For example:
+  
+```php
+  QApplication::$objCacheProvider->sadd('keyS', [2,5,10]) 
+```
+would save 2,5 and 10 into a *Set data structure* named *keyS*.
  
  If you have a persistent Redis instance, you can use the caching system to use the entire Redis functionality using the Predis library.

--- a/docs/Caching/Redis.md
+++ b/docs/Caching/Redis.md
@@ -1,0 +1,33 @@
+# Redis Caching
+
+Redis is a key-value style data-structures store. The key length as well as the value can be as large as 512 MB. The 'value' in Redis can be one of the multiple [data structures](https://redis.io/topics/data-types). 
+ 
+ Performance of Redis depends on whether it is running in persistent mode (saving data to disk) or in-memory mode (all contents are within the specified memory limits). Default configurations run in persistent mode. However, depending on use-case (data structures stored, amount of data stored etc.), performance of Redis can be between "a little slower" to "just a little faster" than memcached. However, implementation of Redis is way more powerful because of the data-structures implementation.
+ 
+ ## Usage of Predis library
+ [Predis](https://github.com/nrk/predis) is the most powerful and popular client library for Redis written in PHP. QCubed uses Predis for using Redis as cache. QCubed's cache system cannot use Redis unless you install Predis. It is also a suggested package in our `composer.json`.
+ 
+ You can simply use `composer require "predis/predis":"^1"` to install. Please see the [project page](https://github.com/nrk/predis) for installation instructions.
+ 
+ ## QCubed Implementation
+ 
+ QCubed's Redis Cache system is non-opinionated. What we mean to convey is - we do not limit you by how you want to set your system up. Start your redis server the way you want (server modes cannot be set by QCubed) and use the connection parameters in the configuration file to connect with the server. 
+ 
+ Redis cache provider's options are taken in an array by using the definition: 
+ 
+```php
+define ('CACHE_PROVIDER_OPTIONS', serialize(
+		array(
+			'parameters' => array(),
+			'options' => array()
+		)
+	));
+```
+
+The configuration **must always contain the 'parameters' and 'options' keys**. These go in the constructor of `Predis\Client`. Please see the [project page](https://github.com/nrk/predis) if you want to use custom connection options for your redis-server installation.
+
+## Full power of Redis is available
+ 
+ The `QApplication::$objCacheProvider` created for Redis Caching is a wrapper around `Predis\Client` instance and can take all commands like `sadd` and `sismember` (e.g. `QApplication::$objCacheProvider->sadd('keyS', [2,5,10])`). 
+ 
+ If you have a persistent Redis instance, you can use the caching system to use the entire Redis functionality using the Predis library.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 # QCubed Documentation
 
-Folders in this directory contain documentation about various parts of QCubed. If you want to learn more, go through them.
+Files and Folders in this directory contain documentation about some parts of QCubed. This is by no means complete and is a work-in-progress, with only a couple or so files of importance. We might add more to this space in future.
 
 For API Documentation, look for the link on [QCubed's GitHub Project Page](http://qcubed.github.io).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# QCubed Documentation
+
+Folders in this directory contain documentation about various parts of QCubed. If you want to learn more, go through them.
+
+For API Documentation, look for the link on [QCubed's GitHub Project Page](http://qcubed.github.io).

--- a/includes/framework/QCacheProviderRedis.class.php
+++ b/includes/framework/QCacheProviderRedis.class.php
@@ -43,11 +43,16 @@
 		}
 
 		/**
-		 * Set the object into the cache with the given key
+		 * Set the object into the cache with the given key and (optional) expire duration
+		 *
+		 * Refer documentation (in docs/Caching/Redis.md) to learn about expiration for redis.
 		 *
 		 * @param string $strKey                the key to use for the object
 		 * @param string $objValue              the object to put in the cache
 		 * @param null   $intExpireAfterSeconds Number of seconds after which the key will be expired
+		 *                                      If this value is numeric, key will expire in that many seconds
+		 *                                      If the value is null and _REDIS_CACHE_PROVIDER_DEFAULT_TTL_ is not set or is negative, then the key will not expire
+		 *                                      If _REDIS_CACHE_PROVIDER_DEFAULT_TTL_ is set and is positive, then key will expire in that many seconds.
 		 *
 		 * @return void
 		 */

--- a/includes/framework/QCacheProviderRedis.class.php
+++ b/includes/framework/QCacheProviderRedis.class.php
@@ -1,0 +1,88 @@
+<?php
+	
+	/**
+	 * Cache provider based on Redis.
+	 *
+	 * This adapter needs the predis/predis library to be installed.
+	 * Please see http://github.com/nrk/predis
+	 */
+	class QCacheProviderRedis extends QAbstractCacheProvider {
+		/** @var Predis\Client */
+		protected $objPredisClient;
+
+		/**
+		 * Construct the Memcache based cache provider
+		 *
+		 * @param array $objOptionsArray array of server options. Each item in the array contains an associative
+		 *                               arrays with options for the server to add to memcache
+		 *
+		 * @throws QCallerException
+		 */
+		public function __construct($objOptionsArray) {
+			// There must be keys named 'parameters' and 'options' in the configuration
+			if(!array_key_exists('parameters', $objOptionsArray) || !array_key_exists('options', $objOptionsArray)) {
+				// Needed keys do not exist
+				throw new QCallerException('The configuration parameters for creating predis client in the configuration file are wrong. The config array must contain the "parameters" and "options" keys');
+			}
+
+			if(class_exists('Predis\Client')) {
+				// We have the predis client
+				$this->objPredisClient = new Predis\Client($objOptionsArray['parameters'], $objOptionsArray['options']);
+			} else {
+				throw new QCallerException('QCacheProviderRedis expects the Predis library to be installed. Please see http://github.com/nrk/predis for more.');
+			}
+		}
+
+		/**
+		 * Get the object that has the given key from the cache
+		 * @param string $strKey the key of the object in the cache
+		 * @return object
+		 */
+		public function Get($strKey) {
+			return unserialize($this->objPredisClient->get($strKey));
+		}
+
+		/**
+		 * Set the object into the cache with the given key
+		 *
+		 * @param string $strKey                the key to use for the object
+		 * @param string $objValue              the object to put in the cache
+		 * @param null   $intExpireAfterSeconds Number of seconds after which the key will be expired
+		 *
+		 * @return void
+		 */
+		public function Set($strKey, $objValue, $intExpireAfterSeconds = null) {
+			$this->objPredisClient->set($strKey, serialize($objValue), 'ex', (int)$intExpireAfterSeconds);
+		}
+
+		/**
+		 * Delete the object that has the given key from the cache
+		 * @param string $strKey the key of the object in the cache
+		 * @return void
+		 */
+		public function Delete($strKey) {
+			$this->objPredisClient->del([$strKey]);
+		}
+
+		/**
+		 * Invalidate all the objects in the cache
+		 * @return void
+		 */
+		public function DeleteAll() {
+			$this->objPredisClient->flushdb();
+		}
+
+		/**
+		 * Let other redis methods work
+		 *
+		 * @param $commandID
+		 * @param $arguments
+		 *
+		 * @return mixed
+		 */
+		public function __call($commandID, $arguments) {
+			return $this->objPredisClient->executeCommand(
+				$this->objPredisClient->createCommand($commandID, $arguments)
+			);
+		}
+	}

--- a/includes/framework/QCacheProviderRedis.class.php
+++ b/includes/framework/QCacheProviderRedis.class.php
@@ -52,7 +52,15 @@
 		 * @return void
 		 */
 		public function Set($strKey, $objValue, $intExpireAfterSeconds = null) {
-			$this->objPredisClient->set($strKey, serialize($objValue), 'ex', (int)$intExpireAfterSeconds);
+			if ($intExpireAfterSeconds !== null) {
+				$this->objPredisClient->set($strKey, serialize($objValue), 'ex', (int)$intExpireAfterSeconds);
+			} else {
+				if(defined('_REDIS_CACHE_PROVIDER_DEFAULT_TTL_') && _REDIS_CACHE_PROVIDER_DEFAULT_TTL_ > 0) {
+					$this->objPredisClient->set($strKey, serialize($objValue), 'ex', (int)_REDIS_CACHE_PROVIDER_DEFAULT_TTL_);
+				} else {
+					$this->objPredisClient->set($strKey, serialize($objValue));
+				}
+			}
 		}
 
 		/**

--- a/includes/qcubed.inc.php
+++ b/includes/qcubed.inc.php
@@ -131,6 +131,7 @@
 	QApplicationBase::$ClassFile['qcacheprovidermemcache'] = __QCUBED_CORE__ . '/framework/QCacheProviderMemcache.class.php';
 	QApplicationBase::$ClassFile['qcacheproviderlocalmemory'] = __QCUBED_CORE__ . '/framework/QCacheProviderLocalMemory.class.php';
 	QApplicationBase::$ClassFile['qcacheprovidernocache'] = __QCUBED_CORE__ . '/framework/QCacheProviderNoCache.class.php';
+	QApplicationBase::$ClassFile['qcacheproviderredis'] = __QCUBED_CORE__ . '/framework/QCacheProviderRedis.class.php';
 	QApplicationBase::$ClassFile['qcacheproviderapc'] = __QCUBED_CORE__ . '/framework/QCacheProviderAPC.class.php';
 	QApplicationBase::$ClassFile['qmultilevelcacheprovider'] = __QCUBED_CORE__ . '/framework/QMultiLevelCacheProvider.class.php';
 	QApplicationBase::$ClassFile['qdbbackedsessionhandler'] = __QCUBED_CORE__ . '/framework/QDbBackedSessionHandler.class.php';

--- a/includes/tests/qcubed-unit/RedisCacheTest.php
+++ b/includes/tests/qcubed-unit/RedisCacheTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Tests for using Redis as a Caching system in QCubed
+ * 
+ * @package Tests
+ */
+
+class RedisCacheTests extends QUnitTestCaseBase {
+	/** @var Predis\Client Redis client which we have to use */
+	protected $objClient;
+
+	public function setUp() {
+		if(class_exists('Predis\Client')) {
+			$this->objClient = new Predis\Client();
+		} else {
+			$this->markTestSkipped(
+				'Predis\Client class not found. Please install predis library. See https://github.com/nrk/predis'
+			);
+		}
+	}
+
+	/**
+	 * Test single element set, get and delete
+	 */
+	public function testSingleElementCache() {
+		$this->objClient->set('singleElementKey', 'singleElementvalue');
+		$cachedResult = $this->objClient->get('singleElementKey');
+		$this->assertEquals ('singleElementvalue', $cachedResult, 'Value not saved into Redis Properly');
+		// Delete
+		$this->objClient->del('singleElementKey');
+		// Check again
+		$cachedResult = $this->objClient->get('singleElementKey');
+		$this->assertNotEquals ('singleElementvalue', $cachedResult, 'Value not deleted from Redis Properly');
+	}
+
+	/**
+	 * Test Single element with auto expiration
+	 */
+	public function testSingleElementCacheWithExpiration() {
+		// Set expiration to 2 seconds
+		$this->objClient->set('singleElementKeyWithExpiration', 'singleElementvalueWhichWillExpire', 'ex', 2);
+		// Get immediately
+		$cachedResult = $this->objClient->get('singleElementKeyWithExpiration');
+		$this->assertEquals ('singleElementvalueWhichWillExpire', $cachedResult, 'Set with expire failed - value was not set');
+		// Sleep for 3 seconds
+		sleep(3);
+		$cachedResult = $this->objClient->get('singleElementKeyWithExpiration');
+		$this->assertNotEquals ('singleElementvalueWhichWillExpire', $cachedResult, 'Set with expire failed - value did not expire');
+	}
+
+	/**
+	 * Test basic set operations. If this is working then other data structures should also work!
+	 */
+	public function testSetOperations() {
+		// add elements into set
+		$this->objClient->sadd ('testSet', 10);
+		$this->objClient->sadd ('testSet', 20);
+		$this->objClient->sadd ('testSet', 30);
+		$this->objClient->sadd ('testSet', 40);
+		$this->objClient->sadd ('testSet', 50);
+		$this->objClient->sadd ('testSet', 60);
+
+		// There should be 6 elements
+		$this->assertEquals(6, $this->objClient->scard('testSet'), 'Unexpected number of elements in set');
+
+		// 40 should be a member
+		$this->assertEquals(1, $this->objClient->sismember('testSet', 40), '40 was not found in set, as expected');
+		// Remove 40 from list
+		$this->objClient->srem('testSet', 40);
+		// See that 40 is no longer a member of set
+		$this->assertNotEquals(1, $this->objClient->sismember('testSet', 40), '40 was still found in set when it should have been removed.');
+		// Remove the key
+		$this->objClient->del(['testSet']);
+		// Cardinality should now be 0
+		$this->assertEquals(0, $this->objClient->scard('testSet'), 'Set was not removed');
+	}
+}

--- a/install/project/includes/configuration/configuration.inc.sample.php
+++ b/install/project/includes/configuration/configuration.inc.sample.php
@@ -321,7 +321,11 @@ if (!defined('SERVER_INSTANCE')) {
 	 * Setting it to null will disable caching. Current implentations are
 	 *
 	 * "QCacheProviderMemcache": this will use Memcache as the caching provider.
-	 *   You must have the 'php5-memcache' package installed for this provider to work.
+	 *   You must have the 'php5-memcache' extensions installed for this provider to work.
+	 *
+	 * "QCacheProviderRedis": this will use a Redis server instance as the caching provider.
+	 *   You must have the 'predis/predis' library installed for this provider to work.
+	 *   See https://github.com/nrk/predis for more info.
 	 *
 	 * "QCacheProviderLocalMemory": a local memory cache provider with a lifespan of the request
 	 *   or session (if KeepInSession is configured).
@@ -365,6 +369,15 @@ if (!defined('SERVER_INSTANCE')) {
 		)
 	));
 	//*/
+
+	/**
+	 * If you want to enable a default TTL for all elements using QCacheProviderRedis,
+	 * set the value below to greater than 0.
+	 * Setting it to 0 or below will disable the TTL functionality.
+	 *
+	 * The value specified here is in seconds.
+	 */
+	define('_REDIS_CACHE_PROVIDER_DEFAULT_TTL_', 10);
 
 	/**
 	 * This is the default algorithm to be used

--- a/install/project/includes/configuration/configuration.inc.sample.php
+++ b/install/project/includes/configuration/configuration.inc.sample.php
@@ -351,6 +351,22 @@ if (!defined('SERVER_INSTANCE')) {
 	) );
 
 	/**
+	 * For Redis caching (using Predis Library)
+	 * Please see https://github.com/nrk/predis/blob/v1.1/README.md for understanding the usage
+	 * of parameters and options
+	 * Leaving them empty here enables default configuration:
+	 *      tcp://127.0.0.1:6379
+	 */
+	/*/
+	define ('CACHE_PROVIDER_OPTIONS', serialize(
+		array(
+			'parameters' => array(),
+			'options' => array()
+		)
+	));
+	//*/
+
+	/**
 	 * This is the default algorithm to be used
 	 *
 	 * QCryptography module can help in encrypting or decrypting

--- a/install/project/includes/configuration/configuration.inc.sample.php
+++ b/install/project/includes/configuration/configuration.inc.sample.php
@@ -373,11 +373,12 @@ if (!defined('SERVER_INSTANCE')) {
 	/**
 	 * If you want to enable a default TTL for all elements using QCacheProviderRedis,
 	 * set the value below to greater than 0.
+	 *
 	 * Setting it to 0 or below will disable the TTL functionality.
 	 *
 	 * The value specified here is in seconds.
 	 */
-	define('_REDIS_CACHE_PROVIDER_DEFAULT_TTL_', 10);
+	define('_REDIS_CACHE_PROVIDER_DEFAULT_TTL_', 3600);
 
 	/**
 	 * This is the default algorithm to be used

--- a/install/project/includes/configuration/configuration.inc.sample.php
+++ b/install/project/includes/configuration/configuration.inc.sample.php
@@ -321,7 +321,7 @@ if (!defined('SERVER_INSTANCE')) {
 	 * Setting it to null will disable caching. Current implentations are
 	 *
 	 * "QCacheProviderMemcache": this will use Memcache as the caching provider.
-	 *   You must have the 'php5-memcache' extensions installed for this provider to work.
+	 *   You must have the 'php5-memcache' extension installed for this provider to work.
 	 *
 	 * "QCacheProviderRedis": this will use a Redis server instance as the caching provider.
 	 *   You must have the 'predis/predis' library installed for this provider to work.


### PR DESCRIPTION
Basic Redis Cache provider built. I have used this in my project and is working fine. 

This Cache Provider has an additional setting for "TTL". Unlike other Caching systems which we have used till now within QCubed do not *persist* data. They use LRU mechanism and are definitely cleared after server restarts. While there is a way to use Redis as a LRU cache (like memcached), the default behavior of redis is to act like a persistent KV store. Also, not everyone is going to run redis as a LRU cache. Their redis installation may not use LRU settings, and in such cases depending on the server's configuration can be troublesome (can fill disk and keep old objects in cache forever). For such cases, the server should clear the contents automatically after some time. I assume caching things for an hour is acceptable. If the user wants to disable/tune this behavior, he can, by editing the configuration file. This behavior is built into Redis and is reliable as well as efficient.

@spekary and @olegabr Please install a Redis server and test it. Also suggest the tests that we need to write for enabling this.

Additionally, I am introducing the 'docs' folder in our top-level directory to make sure that the developer always has enough documentation with him and collaboration around documentation is easy and anyone can contribute to documentation. 

Fixes #1144 