### PR TITLE
Legacy documentation __toString removed

### DIFF
--- a/includes/codegen/templates/db_orm/class_subclass/_main.tpl.php
+++ b/includes/codegen/templates/db_orm/class_subclass/_main.tpl.php
@@ -32,8 +32,6 @@
 		 * Allows pages to _p()/echo()/print() this object, and to define the default
 		 * way this object would be outputted.
 		 *
-		 * Can also be called directly via $obj<?= $objTable->ClassName ?>->__toString().
-		 *
 		 * @return string a nicely formatted string representation of this object
 		 */
 		public function __toString() {


### PR DESCRIPTION
I wouldn't tell the user to use __toString as a function call, I don't think it's a good idea to be calling it like that.