### PR TITLE
bugfix-assertDeprecation

### DIFF
--- a/includes/codegen/templates/db_orm/class_gen/instantiation_methods.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/instantiation_methods.tpl.php
@@ -108,7 +108,7 @@
 <?php } ?>
 <?php if ($objTable->PrimaryKeyColumnArray)  { ?>
 
-				assert ('$key === null || $objToReturn->PrimaryKey() == $key');
+				assert ($key === null || $objToReturn->PrimaryKey() == $key);
 
 				if (!$blnNoCache) {
 					$objToReturn->WriteToCache();


### PR DESCRIPTION
Fixing new problem with PHP nightly - asserts using strings for testing has been deprecated. There are other ways to turn off asserts, like with assert_options, or .ini file directives.