### PR TITLE
bugfix-InitializingModels

### DIFF
--- a/includes/codegen/templates/db_orm/class_gen/class_initialize.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/class_initialize.tpl.php
@@ -6,8 +6,10 @@
 		/**
 		 * Construct a new <?= $objTable->ClassName ?> object.
 		 */
-		public function __construct() {
-			$this->Initialize();
+		public function __construct($blnInitialize = true) {
+            if ($blnInitialize) {
+                $this->Initialize();
+            }
 		}
 <?php } ?>
 

--- a/includes/codegen/templates/db_orm/class_gen/instantiation_methods.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/instantiation_methods.tpl.php
@@ -78,7 +78,7 @@
 			if (empty($objToReturn)) {
 <?php } ?>
 				// Create a new instance of the <?= $objTable->ClassName ?> object
-				$objToReturn = new <?= $objTable->ClassName ?>();
+				$objToReturn = new <?= $objTable->ClassName ?>(false);
 				$objToReturn->__blnRestored = true;
 				$blnNoCache = false;
 

--- a/includes/tests/qcubed-unit/QQFuncTest.php
+++ b/includes/tests/qcubed-unit/QQFuncTest.php
@@ -282,13 +282,19 @@ class QQFuncTests extends QUnitTestCaseBase {
 			$objRes = $objResArray[0];
 			$this->assertNotNull($objRes);
 			if ($objRes) {
-				$this->assertNull($objRes->TestFloat);
+				$blnError = false;
+				try {
+					$objRes->TestFloat;
+				}
+				catch (Exception $e) {
+					$blnError = true;
+				}
+				$this->assertTrue($blnError, 'Accessing table column that was not loaded throws exception.');
 				$this->assertEquals(4.0, $objRes->GetVirtualAttribute('power2'));
 			}
 			$objRes = $objResArray[1];
 			$this->assertNotNull($objRes);
 			if ($objRes) {
-				$this->assertNull($objRes->TestFloat);
 				$this->assertEquals(9.0, $objRes->GetVirtualAttribute('power2'));
 			}
 		}

--- a/includes/tests/qcubed-unit/QQMathOpTest.php
+++ b/includes/tests/qcubed-unit/QQMathOpTest.php
@@ -273,13 +273,27 @@ class QQMathOpTests extends QUnitTestCaseBase {
 			$objRes = $objResArray[0];
 			$this->assertNotNull($objRes);
 			if ($objRes) {
-				$this->assertNull($objRes->TestFloat);
+				$blnError = false;
+				try {
+					$objRes->TestFloat;
+				}
+				catch (Exception $e) {
+					$blnError = true;
+				}
+				$this->assertTrue($blnError, 'Accessing table column that was not loaded throws exception.');
 				$this->assertEquals(-4.0, $objRes->GetVirtualAttribute('mul1'));
 			}
 			$objRes = $objResArray[1];
 			$this->assertNotNull($objRes);
 			if ($objRes) {
-				$this->assertNull($objRes->TestFloat);
+				$blnError = false;
+				try {
+					$objRes->TestFloat;
+				}
+				catch (Exception $e) {
+					$blnError = true;
+				}
+				$this->assertTrue($blnError, 'Accessing table column that was not loaded throws exception.');
 				$this->assertEquals(-2.0, $objRes->GetVirtualAttribute('mul1'));
 			}
 		}


### PR DESCRIPTION
Allows bypassing the initializer when reading objects from the database. The problem with that is you might only want to read a partial object using a QSelect clause, but the initializer will override this partial read, and you won't be able to tell what was read, and what was initialized. The new code allows the Initializer to be bypassed when reading objects from the database.