### PR TITLE
Fixing default QCryptography class behavior

### DIFF
--- a/includes/framework/QCryptography.class.php
+++ b/includes/framework/QCryptography.class.php
@@ -127,8 +127,37 @@ class QCryptography extends QBaseClass {
 			// IV is not needed for the selected algorithm (it could be a ECB algorithm)
 			$this->strIv = null;
 		} else {
-			// Generate random IV
-			$this->strIv = openssl_random_pseudo_bytes($strIvLength);
+			if($strIvHashKey == null) {
+				/*
+				 * IV hash is acceptable but no hash was supplied!
+				 *
+				 * If the default IV hash key's length matches with the length of IV length
+				 * then we will use the default IV
+				 *
+				 * If the length does not match then we throw an exception
+				 */
+				if (strlen(QCRYPTOGRAPHY_DEFAULT_IV) == $strIvLength) {
+					$this->strIv = QCRYPTOGRAPHY_DEFAULT_IV;
+				} else {
+					throw new QCallerException('IV Hash key supplied does not match length required. Required length = ' . $strIvLength . ' Algorithm selected = ' . $this->strCipher);
+				}
+			} else {
+				/*
+				 * IV Hash is acceptable and a hash was supplied!
+				 */
+				if($strIvHashKey == self::IV_RANDOM) {
+					// Random IV was requested
+					// Generate random IV
+					$this->strIv = openssl_random_pseudo_bytes($strIvLength);
+				} else {
+					// We will, once again check if the Hash is of correct length
+					if (strlen($strIvHashKey) == $strIvLength) {
+						$this->strIv = $strIvHashKey;
+					} else {
+						throw new QCallerException('IV Hash key supplied does not match length required. Required length = ' . $strIvLength . ' Algorithm selected = ' . $this->strCipher);
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently, a new QCrytography class instance generates random IV string by default
when an IV is not supplied. This causes a bug wherein, a string encryped by
the default instance will never be decrypted successfully by another default
instance because of IV randomness.

This commit fixes that behavior.

Example script for testing:

```php
<?php
	include 'qcubed.inc.php';

	$strRaw = 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz';
	$objEncQ = new QCryptography();
	$strEnc = $objEncQ->Encrypt($strRaw);

// --- trying to decrypt data in some other file ...

	$objEncQ = new QCryptography();
	$strDec = $objEncQ->Decrypt($strEnc);

	echo "RAW STRING: " . $strRaw . PHP_EOL;
	echo "ENCRYPTED:  " . $strEnc . PHP_EOL;
	echo "DECRYPTED:  " . $strDec . PHP_EOL;

	if ($strRaw == $strDec) {
		echo "Decrypted data matches with Raw data." . PHP_EOL;
	} else {
		echo "Decrypted data does not match with Raw data" . PHP_EOL;
	}
```
The result:

```
RAW STRING: abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
ENCRYPTED:  Z3RFd0JvYmFlMHVMbnVCc2E2azFZaWVMZm41VWVVN3pZdUU0cGtBK1lYV1gwZTZaZEI2SGpyMmtRUEVwQjVKMldWdlNDbnVHYmxScU51dFlFRzIxZ3dLYXI0aDAxRzByMHFJTjlJQXd3QlE9
DECRYPTED:  &ĳ�;���!�%�~Vqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
Decrypted data does not match with Raw data

```

## After applying the current PR

```
RAW STRING: abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
ENCRYPTED:  RFlJd0NPUkZac0dVK0hWQ0Nlb3pVWTJqd2lGdmNzL2NFMmUyZldUMTdoUFVHK05oZWNtM2t2dGZuaUxPbjkwd2EyelNhVVJLK044RmJxZk54ZkcxdzhtcUlVK3ovUmdwVVl4N2QwUlltTVE9
DECRYPTED:  abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
Decrypted data matches with Raw data.
```