### PR TITLE
Changed delimiter for Iv and Hashkey

### DIFF
--- a/includes/framework/QCryptography.class.php
+++ b/includes/framework/QCryptography.class.php
@@ -153,8 +153,8 @@ class QCryptography extends QBaseClass {
 			 * Will increase the size of the resulting value by the size of the IV + about 50%. The other option is to serialize the class or in
 			 * some other way save the IV and restore it later.
 			 */
-			$strEncryptedData .= '=' . bin2hex($this->strIv);
-			$strEncryptedData .= '=' . hash_hmac('sha256', $strEncryptedData, $this->strIvHashKey);
+			$strEncryptedData .= ':' . bin2hex($this->strIv);
+			$strEncryptedData .= ':' . hash_hmac('sha256', $strEncryptedData, $this->strIvHashKey);
 		}
 
 		if ($this->blnBase64) {
@@ -178,7 +178,7 @@ class QCryptography extends QBaseClass {
 		}
 		$strIv = $this->strIv;
 		if ($this->strIvHashKey) {
-			$offset = strrpos($strEncryptedData, "=");
+			$offset = strrpos($strEncryptedData, ":");
 			if ($offset === null) {
 				throw new QCryptographyException("Hash value not found.");
 			}
@@ -191,7 +191,7 @@ class QCryptography extends QBaseClass {
 				throw new QCryptographyException("Encryption tampering detected");
 			}
 
-			$offset2 = strrpos($strEncryptedData, "=");
+			$offset2 = strrpos($strEncryptedData, ":");
 
 			if ($offset2 === null) {
 				throw new QCryptographyException("IV not found.");


### PR DESCRIPTION
The '=' character is padding character in raw base64 encoded string.
It is removed in the QString::Base64UrlSafeEncode method (or the same implementation
in QCryptography class earlier). When trying to use base64 encoding built into
QCryptography class, the decryption fails because the base64 encoded data will
eventually lack the delimiting character.

The ':' character is outside the base64 character set and thus, when encoding,
the delimiter would not be lost.

I am facing that as a major issue with `=`. Changing it to `:` makes it work. 