### PR TITLE
bugfix-AssertControlId

### DIFF
--- a/includes/base_controls/_actions.inc.php
+++ b/includes/base_controls/_actions.inc.php
@@ -456,6 +456,7 @@
 		 */
 		public function __construct(QControl $objControl, $strMethodName, $objWaitIconControl = 'default',
 		                            $mixCausesValidationOverride = null, $strJsReturnParam = "", $blnAsync = false) {
+			assert($objControl->ControlId != '');	// Are you adding an action before adding the control to the form?
 			parent::__construct($objControl->ControlId . ':' . $strMethodName, $objWaitIconControl, $mixCausesValidationOverride, $strJsReturnParam, $blnAsync);
 		}
 	}


### PR DESCRIPTION
Adding an assert for new QCubed users to prevent them from adding an action to a control that has not been added to a form.