### PR TITLE
bugfix-Callable

### DIFF
--- a/assets/php/examples/datarepeater/ajax.php
+++ b/assets/php/examples/datarepeater/ajax.php
@@ -34,7 +34,7 @@ class DataRepeaterExample extends QForm {
 		$this->dtrBig->SetDataBinder('dtrBig_Bind');
 		$this->dtrBig->TagName = 'ul';
 		$this->dtrBig->ItemTagName = 'li';
-		$this->dtrBig->ItemInnerHtmlCallback = 'BigItem_Render';
+		$this->dtrBig->ItemInnerHtmlCallback = [$this, 'BigItem_Render'];
 	}
 
 	protected function dtrPersons_Bind() {
@@ -63,4 +63,3 @@ class DataRepeaterExample extends QForm {
 }
 
 DataRepeaterExample::Run('DataRepeaterExample');
-?>

--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -534,7 +534,7 @@
 		 * in the serialized stream differently than the default. If a QControl, make sure this isn't the only
 		 * instance of the control in the stream, or have some other way to serialize the control.
 		 *
-		 * @param QForm|QControl|array|Callable $obj
+		 * @param QForm|QControl|array|callable $obj
 		 * @return mixed
 		 */
 		public static function SleepHelper($obj) {

--- a/includes/base_controls/QDataRepeater.class.php
+++ b/includes/base_controls/QDataRepeater.class.php
@@ -7,7 +7,7 @@
  * corresponding callbacks for those methods.
  *
  * The callbacks below can be specified as either a string, or an array. If a string, it should be the name of a
- * public method in the parent form. If an array, it should be a PHP Callable array. If your callback is a method in
+ * public method in the parent form. If an array, it should be a PHP callable array. If your callback is a method in
  * a form, do NOT pass the form object in to the array, but rather just pass the name of the method as a string.
  * (This is due to a problem PHP has with serializing recursive objects.) If its a method in a control, pass an array
  * with the control and method name, i.e. [$objControl, 'RenderMethod']
@@ -20,17 +20,17 @@
  * @property 		string 	$Template			A php template file that will be evaluated for each item. The template will have
  * 												$_ITEM as the item in the DataSource array, $_CONTROL as this control, and $_FORM as
  * 												the form object. If you provide a template, the callbacks will not be used.
- * @property-write 	string $ItemHtmlCallback	A Callable which will be called to get the html for each item.
+ * @property-write 	callable $ItemHtmlCallback	A PHP callable which will be called to get the html for each item.
  * 												Parameters passed are the item from the DataSource array, and the index of the
  * 												item being drawn. The callback should return the entire html for the item. If
  * 												you provide this callback, the ItemAttributesCallback and ItemInnerHtmlCallback
  * 												will not be used.
- * @property-write 	string $ItemAttributesCallback	A Callable which will be called to get the attributes for each item.
+ * @property-write 	callable $ItemAttributesCallback	A PHP callable which will be called to get the attributes for each item.
  * 												Use this with the ItemInnerHtmlCallback and the ItemTagName. The callback
  * 												will be passed the item and the index of the item. It should return key/value
  * 												pairs which will be used as the attributes for the item's tag. Use only
  * 												if you are not using a Template or the ItemHtmlCallback.
- * @property-write 	string $ItemInnerHtmlCallback	A Callable which will be called to get the inner html for each item.
+ * @property-write 	callable $ItemInnerHtmlCallback	A PHP callable which will be called to get the inner html for each item.
  * 												Use this with the ItemAttributesCallback and the ItemTagName. The callback
  * 												will be passed the item and the index of the item. It should return the complete
  * 												text to appear inside the open and close tags for the item.	 *
@@ -51,11 +51,11 @@ class QDataRepeater extends QPaginatedControl {
 	/** @var string  */
 	protected $strItemTagName = 'div';
 
-	/** @var  Callable | string */
+	/** @var  callable */
 	protected $itemHtmlCallback;
-	/** @var  Callable | string */
+	/** @var  callable */
 	protected $itemAttributesCallback;
-	/** @var  Callable | string */
+	/** @var  callable */
 	protected $itemInnerHtmlCallback;
 
 
@@ -80,12 +80,7 @@ class QDataRepeater extends QPaginatedControl {
 		if ($this->strTemplate) {
 			return $this->EvaluateTemplate($this->strTemplate);
 		} elseif ($this->itemHtmlCallback) {
-			if (is_string($this->itemHtmlCallback)) {
-				$strMethod = $this->itemHtmlCallback;
-				return $this->objForm->$strMethod($objItem, $this->intCurrentItemIndex);
-			} else {
-				return call_user_func($this->itemHtmlCallback, $objItem, $this->intCurrentItemIndex);
-			}
+			return call_user_func($this->itemHtmlCallback, $objItem, $this->intCurrentItemIndex);
 		}
 
 		if (!$this->strItemTagName) {
@@ -106,12 +101,7 @@ class QDataRepeater extends QPaginatedControl {
 	 */
 	protected function GetItemAttributes ($objItem) {
 		if ($this->itemAttributesCallback) {
-			if (is_string($this->itemAttributesCallback)) {
-				$strMethod = $this->itemAttributesCallback;
-				return $this->objForm->$strMethod($objItem, $this->intCurrentItemIndex);
-			} else {
-				return call_user_func($this->itemAttributesCallback, $objItem, $this->intCurrentItemIndex);
-			}
+			return call_user_func($this->itemAttributesCallback, $objItem, $this->intCurrentItemIndex);
 		}
 		return null;
 	}
@@ -125,12 +115,7 @@ class QDataRepeater extends QPaginatedControl {
 	 */
 	protected function GetItemInnerHtml($objItem) {
 		if ($this->itemInnerHtmlCallback) {
-			if (is_string($this->itemInnerHtmlCallback)) {
-				$strMethod = $this->itemInnerHtmlCallback;
-				return $this->objForm->$strMethod($objItem, $this->intCurrentItemIndex);
-			} else {
-				return call_user_func($this->itemInnerHtmlCallback, $objItem, $this->intCurrentItemIndex);
-			}
+			return call_user_func($this->itemInnerHtmlCallback, $objItem, $this->intCurrentItemIndex);
 		}
 		return $objItem->__toString();	// default to rendering a database object
 	}
@@ -170,6 +155,27 @@ class QDataRepeater extends QPaginatedControl {
 
 		$this->objDataSource = null;
 		return $strToReturn;
+	}
+
+	/**
+	 * Fix up possible embedded reference to the form.
+	 */
+	public function Sleep() {
+		$this->itemHtmlCallback = QControl::SleepHelper($this->itemHtmlCallback);
+		$this->itemAttributesCallback = QControl::SleepHelper($this->itemAttributesCallback);
+		$this->itemInnerHtmlCallback = QControl::SleepHelper($this->itemInnerHtmlCallback);
+		parent::Sleep();
+	}
+
+	/**
+	 * Restore serialized references.
+	 * @param QForm $objForm
+	 */
+	public function Wakeup(QForm $objForm) {
+		parent::Wakeup($objForm);
+		$this->itemHtmlCallback = QControl::WakeupHelper($objForm, $this->itemHtmlCallback);
+		$this->itemAttributesCallback = QControl::WakeupHelper($objForm, $this->itemAttributesCallback);
+		$this->itemInnerHtmlCallback = QControl::WakeupHelper($objForm, $this->itemInnerHtmlCallback);
 	}
 
 	/////////////////////////
@@ -255,30 +261,23 @@ class QDataRepeater extends QPaginatedControl {
 				}
 
 			case 'ItemHtmlCallback':
-				$this->blnModified = true;
-				if (is_array($mixValue) && reset($mixValue) === $this->objForm) {
-					// Do not pass [$objForm, 'methodName']. Rather, just set to 'methodName', and the form will be searched for that method.
-					throw new QCallerException ('Do not pass the form object in a callable array. Instead, just pass the method name.');
+				try {
+					$this->blnModified = true;
+					$this->itemHtmlCallback = QType::Cast($mixValue, QType::CallableType);
+				} catch (QInvalidCastException $objExc) {
+					$objExc->IncrementOffset();
+					throw $objExc;
 				}
-				$this->itemHtmlCallback = $mixValue;
 				break;
 
 			case 'ItemAttributesCallback':	// callback should return an array of key/value items
 				$this->blnModified = true;
-				if (is_array($mixValue) && reset($mixValue) === $this->objForm) {
-					// Do not pass [$objForm, 'methodName']. Rather, just set to 'methodName', and the form will be searched for that method.
-					throw new QCallerException ('Do not pass the form object in a callable array. Instead, just pass the method name.');
-				}
-				$this->itemAttributesCallback = $mixValue;
+				$this->itemAttributesCallback = QType::Cast($mixValue, QType::CallableType);;
 				break;
 
 			case 'ItemInnerHtmlCallback':
 				$this->blnModified = true;
-				if (is_array($mixValue) && reset($mixValue) === $this->objForm) {
-					// Do not pass [$objForm, 'methodName']. Rather, just set to 'methodName', and the form will be searched for that method.
-					throw new QCallerException ('Do not pass the form object in a callable array. Instead, just pass the method name.');
-				}
-				$this->itemInnerHtmlCallback = $mixValue;
+				$this->itemInnerHtmlCallback = QType::Cast($mixValue, QType::CallableType);;
 				break;
 
 			default:

--- a/includes/base_controls/QHtmlTableBase.class.php
+++ b/includes/base_controls/QHtmlTableBase.class.php
@@ -21,7 +21,7 @@
 	 * @property boolean        $ShowFooter           true to show the footer row
 	 * @property boolean        $RenderColumnTags     true to include col tags in the table output
 	 * @property boolean        $HideIfEmpty          true to completely hide the table if there is no data, vs. drawing the table with no rows.
-	 * @property-write Callable $RowParamsCallback    Set to a callback function to fetch custom attributes for row tags.
+	 * @property-write callable $RowParamsCallback    Set to a callback function to fetch custom attributes for row tags.
 	 * @property-read integer 	$CurrentRowIndex      The visual index of the row currently being drawn.
 	 * @throws QCallerException
 	 *
@@ -55,8 +55,8 @@
 		/** @var  integer Used during rendering to report which visible row is being drawn. */
 		protected $intCurrentRowIndex;
 
-		/** @var  callable */
-		protected $objRowParamsCallback;
+		/** @var callable */
+		protected $rowParamsCallback;
 
 		/**
 		 * Constructor method
@@ -569,8 +569,8 @@
 		 */
 		protected function GetRowParams ($objObject, $intCurrentRowIndex) {
 			$strParamArray = array();
-			if ($this->objRowParamsCallback) {
-				$strParamArray = call_user_func($this->objRowParamsCallback, $objObject, $intCurrentRowIndex);
+			if ($this->rowParamsCallback) {
+				$strParamArray = call_user_func($this->rowParamsCallback, $objObject, $intCurrentRowIndex);
 			}
 			if ($strClass = $this->GetRowClass ($objObject, $intCurrentRowIndex)) {
 				$strParamArray['class'] = $strClass;
@@ -724,7 +724,7 @@
 					$objColumn->Sleep();
 				}
 			}
-			$this->objRowParamsCallback = QControl::SleepHelper($this->objRowParamsCallback);
+			$this->rowParamsCallback = QControl::SleepHelper($this->rowParamsCallback);
 			parent::Sleep();
 		}
 
@@ -735,7 +735,7 @@
 		 */
 		public function Wakeup(QForm $objForm) {
 			parent::Wakeup($objForm);
-			$this->objRowParamsCallback = QControl::WakeupHelper($objForm, $this->objRowParamsCallback);
+			$this->rowParamsCallback = QControl::WakeupHelper($objForm, $this->rowParamsCallback);
 			if ($this->objColumnArray) {
 				foreach ($this->objColumnArray as $objColumn) {
 					$objColumn->Wakeup($objForm);
@@ -883,8 +883,7 @@
 
 				case "RowParamsCallback":
 					try {
-						assert (is_callable($mixValue));
-						$this->objRowParamsCallback = $mixValue;
+						$this->rowParamsCallback = QType::Cast($mixValue, QType::CallableType);
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();

--- a/includes/base_controls/QHtmlTableColumn.class.php
+++ b/includes/base_controls/QHtmlTableColumn.class.php
@@ -39,7 +39,7 @@
 		protected $strId = null;
 		/** @var bool Easy way to hide a column without removing the column. */
 		protected $blnVisible = true;
-		/** @var Callable Callback to modify the html attributes of the generated cell. */
+		/** @var callable Callback to modify the html attributes of the generated cell. */
 		protected $cellParamsCallback = null;
 		/** @var QTagStyler Styles for each cell. Usually this should be done in css for efficient code generation. */
 		protected $objCellStyler;
@@ -414,7 +414,7 @@
 					}
 
 				case "CellParamsCallback":
-					$this->cellParamsCallback = $mixValue;
+					$this->cellParamsCallback = QType::Cast($mixValue, QType::CallableType);
 					break;
 
 				case "_ParentTable":
@@ -876,7 +876,7 @@
 	 */
 	class QHtmlTableCallableColumn extends QAbstractHtmlTableDataColumn {
 		/** @var callback */
-		protected $objCallable;
+		protected $callback;
 		/** @var array extra parameters passed to closure */
 		protected $mixParams;
 
@@ -896,15 +896,15 @@
 			if ($objCallable instanceof Closure) {
 				throw new InvalidArgumentException('Cannot be a Closure.');
 			}
-			$this->objCallable = $objCallable;
+			$this->callback = $objCallable;
 			$this->mixParams = $mixParams;
 		}
 
 		public function FetchCellObject($item) {
 			if ($this->mixParams) {
-				return call_user_func($this->objCallable, $item, $this->mixParams);
+				return call_user_func($this->callback, $item, $this->mixParams);
 			} else {
-				return call_user_func($this->objCallable, $item);
+				return call_user_func($this->callback, $item);
 			}
 		}
 
@@ -912,7 +912,7 @@
 		 * Fix up possible embedded reference to the form.
 		 */
 		public function Sleep() {
-			$this->objCallable = QControl::SleepHelper($this->objCallable);
+			$this->callback = QControl::SleepHelper($this->callback);
 			parent::Sleep();
 		}
 
@@ -922,7 +922,7 @@
 		 */
 		public function Wakeup(QForm $objForm) {
 			parent::Wakeup($objForm);
-			$this->objCallable = QControl::WakeupHelper($objForm, $this->objCallable);
+			$this->callback = QControl::WakeupHelper($objForm, $this->callback);
 		}
 
 		/**
@@ -937,7 +937,7 @@
 		public function __get($strName) {
 			switch ($strName) {
 				case 'Callable':
-					return $this->objCallable;
+					return $this->callback;
 				default:
 					try {
 						return parent::__get($strName);
@@ -962,10 +962,7 @@
 		public function __set($strName, $mixValue) {
 			switch ($strName) {
 				case "Callable":
-					if (!is_callable($mixValue)) {
-						throw new QInvalidCastException("Callable must be a callable object");
-					}
-					$this->objCallable = $mixValue;
+					$this->callback = QType::Cast($mixValue, QType::CallableType);
 					break;
 
 				default:

--- a/includes/framework/QType.class.php
+++ b/includes/framework/QType.class.php
@@ -84,8 +84,8 @@
 		const DateTime = 'QDateTime';
 		/** Resource Type */
 		const Resource = 'resource';
-		/** Callable Type  - Note: For QCubed, QType::Callables CANNOT be Closures (because they cannot be serialized into the form state) */
-		const Callable = 'callable';
+		/** Callable Type  - Note: For QCubed, QType::CallableTypes CANNOT be Closures (because they cannot be serialized into the form state) */
+		const CallableType = 'callable';
 
 		// Virtual types
 		const Association = 'association';
@@ -122,7 +122,7 @@
 					}
 				}
 				elseif ($strObjName == 'Closure') {
-					if ($strType == QType::Callable) {
+					if ($strType == QType::CallableType) {
 						throw new Exception("Can't use a closure here"); // will get rethrown below, but this will error to
 																		// prevent you from accidentally sending a Closure to a callable in a form object.
 																		// that cannot be done, because Closures are not serializable. Some other forms of
@@ -245,7 +245,7 @@
 					
 					return $strItem;
 
-				case QType::Callable:
+				case QType::CallableType:
 					if (is_callable($mixItem)) {
 						return $mixItem;
 					} else {
@@ -270,7 +270,7 @@
 			if ($strType == QType::ArrayType) {
 				return $arrItem;
 			}
-			elseif ($strType == QType::Callable && is_callable($arrItem)) {
+			elseif ($strType == QType::CallableType && is_callable($arrItem)) {
 				return $arrItem;
 			}
 			else {
@@ -427,7 +427,7 @@
 					return QType::DateTime;
 
 				case 'callable':
-					return QType::Callable;
+					return QType::CallableType;
 
 				case 'null':
 				case 'void':

--- a/includes/framework/QType.class.php
+++ b/includes/framework/QType.class.php
@@ -84,6 +84,8 @@
 		const DateTime = 'QDateTime';
 		/** Resource Type */
 		const Resource = 'resource';
+		/** Callable Type  - Note: For QCubed, QType::Callables CANNOT be Closures (because they cannot be serialized into the form state) */
+		const Callable = 'callable';
 
 		// Virtual types
 		const Association = 'association';
@@ -98,7 +100,8 @@
 		private static function CastObjectTo($objItem, $strType) {
 			try {
 				$objReflection = new ReflectionClass($objItem);
-				if ($objReflection->getName() == 'SimpleXMLElement') {
+				$strObjName = $objReflection->getName();
+				if ($strObjName == 'SimpleXMLElement') {
 					switch ($strType) {
 						case QType::String:
 							return (string) $objItem;
@@ -116,6 +119,14 @@
 								return false;
 							else
 								return true;
+					}
+				}
+				elseif ($strObjName == 'Closure') {
+					if ($strType == QType::Callable) {
+						throw new Exception("Can't use a closure here"); // will get rethrown below, but this will error to
+																		// prevent you from accidentally sending a Closure to a callable in a form object.
+																		// that cannot be done, because Closures are not serializable. Some other forms of
+																		// callables ARE serializable though, so use that instaed.
 					}
 				}
 
@@ -234,6 +245,13 @@
 					
 					return $strItem;
 
+				case QType::Callable:
+					if (is_callable($mixItem)) {
+						return $mixItem;
+					} else {
+						throw new QInvalidCastException(sprintf('Unable to cast %s value to callable', $strOriginalType));
+					}
+
 				default:
 					throw new QInvalidCastException(sprintf('Unable to cast %s value to unknown type %s', $strOriginalType, $strNewType));
 			}
@@ -245,13 +263,17 @@
 		 * @param array  $arrItem The array item to be converted
 		 * @param string $strType Type to which this array has to be converted
 		 *
-		 * @return string
+		 * @return array
 		 * @throws QInvalidCastException
 		 */
 		private static function CastArrayTo($arrItem, $strType) {
 			if ($strType == QType::ArrayType) {
 				return $arrItem;
-			} else {
+			}
+			elseif ($strType == QType::Callable && is_callable($arrItem)) {
+				return $arrItem;
+			}
+			else {
 				throw new QInvalidCastException(sprintf('Unable to cast Array to %s', $strType));
 			}
 		}
@@ -403,6 +425,9 @@
 				case 'time':
 				case 'qdatetime':
 					return QType::DateTime;
+
+				case 'callable':
+					return QType::Callable;
 
 				case 'null':
 				case 'void':


### PR DESCRIPTION
Adding a "CallableType" type to QType to make type checking on Callables more consistent, and to help with the process of making sure a callable is serializable into the form state (not all callable types are).

Also, went through the code and fixed places where callables were not be correctly serialized.

This has a possible breaking change in that the QDataRepeater callbacks should use a standard callable when referring to function in the QForm, rather than just a string for a function name. This change makes the managing of the callable more standard with QCubed overall and how PHP currently lets you specify callbacks that are methods in objects.