### PR TITLE
bugfix-DialogImprovements

### DIFF
--- a/assets/js/qcubed.js
+++ b/assets/js/qcubed.js
@@ -26,11 +26,17 @@ $j.fn.extend({
  */
 $j.ajaxQueue = function(o, blnAsync) {
     if (typeof $j.ajaxq === "undefined" || blnAsync) {
-        $j.ajax(o());
+        $j.ajax(o()); // fallback in case ajaxq is not here
     } else {
-        $j.ajaxq("qcu.be", o);
+        var p = $j.ajaxq("qcu.be", o);
     }
 };
+$j.ajaxQueueIsRunning = function() {
+    if ($j.ajaxq) {
+        return $j.ajaxq.isRunning("qcu.be");
+    }
+    return false;
+}
 
 
 /**
@@ -40,7 +46,7 @@ qcubed = {
     /**
      * @param {string} strControlId
      * @param {string} strProperty
-     * @param {string|ARray|Object} strNewValue
+     * @param {string|Array|Object} strNewValue
      */
     recordControlModification: function(strControlId, strProperty, strNewValue) {
         if (!qcubed.controlModifications[strControlId]) {
@@ -518,6 +524,13 @@ qcubed = {
             }
         }
 
+        $j( document ).ajaxComplete(function( event, request, settings ) {
+            if (!$j.ajaxQueueIsRunning()) {
+                qcubed.processFinalCommands();
+            }
+        });
+
+
         return this;
     },
     processImmediateAjaxResponse: function(json, qFormParams) {
@@ -589,42 +602,12 @@ qcubed = {
     processDeferredAjaxResponse: function(json) {
         if (json.commands) { // commands
             $j.each(json.commands, function (index, command) {
-                if (command.script) {
-                    /** @todo eval is evil, do no evil */
-                    eval (command.script);
-                }
-                else if (command.selector) {
-                    var params = qc.unpackArray(command.params);
-                    var objs;
+                if (command.final &&
+                    $j.ajaxQueueIsRunning()) {
 
-                    if (typeof command.selector === 'string') {
-                        objs = $j(command.selector);
-                    } else {
-                        objs = $j(command.selector[0], command.selector[1]);
-                    }
-
-                    // apply the function on each jQuery object found, using the found jQuery object as the context.
-                    objs.each (function () {
-                        var $item = $j(this);
-                        if ($item[command.func]) {
-                            $item[command.func].apply($j(this), params);
-                        }
-                    });
-                }
-                else if (this.func) {
-                    var params = qc.unpackArray(this.params);
-
-                    // Find the function by name. Walk an object list in the process.
-                    var objs = this.func.split(".");
-                    var obj = window;
-                    var ctx = null;
-
-                    $j.each (objs, function (i, v) {
-                        ctx = obj;
-                        obj = obj[v];
-                    });
-                    // obj is now a function object, and ctx is the parent of the function object
-                    obj.apply(ctx, params);
+                    qcubed.enqueueFinalCommand(command);
+                } else {
+                    qcubed.processCommand(command);
                 }
             });
         }
@@ -642,7 +625,55 @@ qcubed = {
         if (qcubed.objAjaxWaitIcon) {
             $j(qcubed.objAjaxWaitIcon).hide();
         }
+    },
+    processCommand: function(command) {
+        if (command.script) {
+            /** @todo eval is evil, do no evil */
+            eval (command.script);
+        }
+        else if (command.selector) {
+            var params = qc.unpackArray(command.params);
+            var objs;
 
+            if (typeof command.selector === 'string') {
+                objs = $j(command.selector);
+            } else {
+                objs = $j(command.selector[0], command.selector[1]);
+            }
+
+            // apply the function on each jQuery object found, using the found jQuery object as the context.
+            objs.each (function () {
+                var $item = $j(this);
+                if ($item[command.func]) {
+                    $item[command.func].apply($j(this), params);
+                }
+            });
+        }
+        else if (this.func) {
+            var params = qc.unpackArray(this.params);
+
+            // Find the function by name. Walk an object list in the process.
+            var objs = this.func.split(".");
+            var obj = window;
+            var ctx = null;
+
+            $j.each (objs, function (i, v) {
+                ctx = obj;
+                obj = obj[v];
+            });
+            // obj is now a function object, and ctx is the parent of the function object
+            obj.apply(ctx, params);
+        }
+
+    },
+    enqueueFinalCommand: function(command) {
+        qcubed.finalCommands.push(command);
+    },
+    processFinalCommands: function() {
+        while(qcubed.finalCommands.length) {
+            var command = qcubed.finalCommands.pop();
+            qcubed.processCommand(command);
+        }
     },
     /**
      * Convert from JSON return value to an actual jQuery object. Certain structures don't work in JSON, like closures,
@@ -922,6 +953,13 @@ qcubed.datagrid2 = function(controlId) {
     });
 };
 
+qcubed.dialog = function(controlId) {
+    $j('#' + controlId).on("tabsactivate", function(event, ui) {
+        var i = $j(this).tabs( "option", "active" );
+        var id = ui.newPanel ? ui.newPanel.attr("id") : null;
+        qcubed.recordControlModification(controlId, "_active", [i,id]);
+    });
+}
 
 /////////////////////////////////
 // Controls-related functionality
@@ -991,6 +1029,7 @@ qcubed.javascriptWrapperStyleToQcubed.top = "Top";
 qcubed.javascriptWrapperStyleToQcubed.left = "Left";
 
 qcubed.blockEvents = false;
+qcubed.finalCommands = [];
 
 qcubed.registerControl = function(mixControl) {
     var objControl = qcubed.getControl(mixControl),

--- a/assets/php/examples/advanced_ajax/dialog_box.php
+++ b/assets/php/examples/advanced_ajax/dialog_box.php
@@ -13,7 +13,6 @@
 		protected $txtValue;
 		protected $btnCalculator;
 
-		protected $dlgYesNo;
 		protected $pnlAnswer;
 		protected $btnDisplayYesNo;
 
@@ -44,7 +43,7 @@
 
 			// The First "Display Simple Message" button will utilize an AJAX call to Show the Dialog Box
 			$this->btnDisplaySimpleMessage = new QButton($this);
-			$this->btnDisplaySimpleMessage->Text = 'Display Simple Message QDialog';
+			$this->btnDisplaySimpleMessage->Text = QApplication::Translate('Display Simple Message QDialog');
 			$this->btnDisplaySimpleMessage->AddAction(new QClickEvent(), new QAjaxAction('btnDisplaySimpleMessage_Click'));
 
 			// The Second "Display Simple Message" button will utilize Client Side-only JavaScripts to Show the Dialog Box
@@ -53,25 +52,12 @@
 			$this->btnDisplaySimpleMessageJsOnly->Text = 'Display Simple Message QDialog (ClientSide Only)';
 			$this->btnDisplaySimpleMessageJsOnly->AddAction(new QClickEvent(), new QShowDialog($this->dlgSimpleMessage));
 
-
-			// Define a Yes/No modal dialog box
-			$this->dlgYesNo = new QDialog($this);
-			$this->dlgYesNo->Text = "Do you like QCubed?";
-			$this->dlgYesNo->AddButton ('Yes');
-			$this->dlgYesNo->AddButton ('No');
-			$this->dlgYesNo->AddAction (new QDialog_ButtonEvent(), new QHideDialog ($this->dlgYesNo));
-			$this->dlgYesNo->AddAction (new QDialog_ButtonEvent(), new QAjaxAction ('dlgYesNo_Button'));
-			$this->dlgYesNo->AutoOpen = false;
-			$this->dlgYesNo->Modal = true;
-			$this->dlgYesNo->Resizable = false;
-			$this->dlgYesNo->HasCloseButton = false;
-
 			$this->pnlAnswer = new QPanel($this);
 			$this->pnlAnswer->Text = 'Hmmm';
 			
 			$this->btnDisplayYesNo = new QButton($this);
-			$this->btnDisplayYesNo->Text = 'Do you love me.';
-			$this->btnDisplayYesNo->AddAction(new QClickEvent(), new QShowDialog($this->dlgYesNo));
+			$this->btnDisplayYesNo->Text = QApplication::Translate('Do you love me?');
+			$this->btnDisplayYesNo->AddAction(new QClickEvent(), new QAjaxAction('showYesNoClick'));
 			
 			
 			// Define the CalculatorWidget example. passing in the Method Callback for whenever the Calculator is Closed
@@ -80,6 +66,7 @@
 			$this->dlgCalculatorWidget->Title = "Calculator Widget";
 			$this->dlgCalculatorWidget->AutoOpen = false;
 			$this->dlgCalculatorWidget->Resizable = false;
+			$this->dlgCalculatorWidget->Modal = false;
 
 			// Setup the Value Textbox and Button for this example
 			$this->txtValue = new QTextBox($this);
@@ -126,23 +113,13 @@
 			// "Show" the Dialog Box using the Open() method
 			$this->dlgSimpleMessage->Open();
 		}
-		
-		protected function dlgYesNo_Button($strFormId, $strControlId, $strParameter) {
-			if ($strParameter == 'Yes') {
-				$this->pnlAnswer->Text = 'They love me.';
-			} else {
-				$this->pnlAnswer->Text = 'They love me not.';
-			}
-		}
-		
-		
+
 		protected function btnCalculator_Click($strFormId, $strControlId, $strParameter) {
 			// Setup the Calculator Widget's Value
 			$this->dlgCalculatorWidget->Value = trim($this->txtValue->Text);
 
 			// And Show it
 			$this->dlgCalculatorWidget->Open();
-			//$this->dlgCalculatorWidget->ShowDialogBox();
 		}
 
 		public function dlgValidate_Click($strFormId, $strControlId, $strParameter) {
@@ -206,6 +183,31 @@
 			QDialog::Alert($strParameter . ' was clicked.', ['OK']);
 		}
 
+		/**
+		 * This example shows how you can create an advanced dialog without creating a new control in the
+		 * form object. You will need to specify some way of closing the dialog.
+		 */
+		protected function showYesNoClick() {
+
+			$dlgYesNo = new QDialog();	// Note here there is no "$this" as the first parameter. By leaving this off, you
+										// are telling QCubed to manage the dialog.
+			$dlgYesNo->Text = QApplication::Translate("Do you like QCubed?");
+			$dlgYesNo->AddButton ('Yes');
+			$dlgYesNo->AddButton ('No');
+			$dlgYesNo->AddAction (new QDialog_ButtonEvent(), new QAjaxAction ('dlgYesNo_Button'));
+			$dlgYesNo->Resizable = false;
+			$dlgYesNo->HasCloseButton = false;
+		}
+
+		protected function dlgYesNo_Button($strFormId, $strControlId, $strParameter) {
+			$dlg = $this->GetControl($strControlId);	// get the dialog object from the form.
+			if ($strParameter == 'Yes') {
+				$this->pnlAnswer->Text = QApplication::Translate('They love me');
+			} else {
+				$this->pnlAnswer->Text = QApplication::Translate('They love me not');
+			}
+			$dlg->Close();
+		}
 
 	}
 

--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -638,7 +638,9 @@
 		 * @param boolean $blnRemoveFromForm should the control be removed from the form, too?
 		 */
 		public function RemoveChildControl($strControlId, $blnRemoveFromForm) {
-			$this->blnModified = true;
+			$this->blnModified = true;	// TODO: Find a way to remove control in javascript so we don't have to redraw the entire control
+										// Its a bit tricky because of the recursive nature of this function
+
 			if (isset($this->objChildControlArray[$strControlId])) {
 				$objChildControl = $this->objChildControlArray[$strControlId];
 				$objChildControl->objParentControl = null;
@@ -1065,7 +1067,7 @@
 			}
 
 			// TODO: do this in javascript
-			// QApplication::ExecuteControlCommand($this->WrapperId, 'removeClass', $this->strValidationState);
+			// QApplication::ExecuteControlCommand($this->GetWrapperId(), 'removeClass', $this->strValidationState);
 
 		}
 
@@ -1137,7 +1139,7 @@
 		 */
 		protected function RenderWrappedOutput($strOutput, $blnForceAsBlockElement = false) {
 			$strTag = ($this->blnIsBlockElement || $blnForceAsBlockElement) ? 'div' : 'span';
-			$overrides = ['id'=>$this->strControlId . '_ctl'];
+			$overrides = ['id'=>$this->GetWrapperId()];
 			$attributes = $this->GetWrapperAttributes($overrides);
 
 			return QHtml::RenderTag($strTag, $attributes, $strOutput);
@@ -1522,7 +1524,7 @@
 				if (!isset($wrapperAttributes['style'])) {
 					$wrapperAttributes['style'] = '';	// must specifically turn off styles if none were drawn, in case the previous state had a style and it had changed
 				}
-				$controls[] = [QAjaxResponse::Id=>$this->strControlId . '_ctl', QAjaxResponse::Attributes=>$wrapperAttributes];
+				$controls[] = [QAjaxResponse::Id=>$this->GetWrapperId(), QAjaxResponse::Attributes=>$wrapperAttributes];
 			}
 			return $controls;
 		}
@@ -1852,7 +1854,7 @@
 		 * Used by jQuery UI wrapper controls to find the element on which to apply the jQuery  function
 		 *
 		 * NOTE: Some controls that use jQuery will get wrapped with extra divs by the jQuery library.
-		 * If such a control then gets replaced by Ajax, the jQuery effects will be deleted. To solve this,
+		 * If such a control then gets replaced by Ajax during a redraw, the jQuery effects will be deleted. To solve this,
 		 * the corresponding QCubed control should set UseWrapper to true, attach the jQuery effect to
 		 * the wrapper, and override this function to return the id of the wrapper. See QDialogBase.class.php for
 		 * an example.
@@ -1861,6 +1863,19 @@
 		 */
 		public function GetJqControlId() {
 			return $this->ControlId;
+		}
+
+		/**
+		 * Returns the top level control id, which is the wrapper id of a wrapper is being used.
+		 *
+		 * @return string
+		 */
+		public function GetWrapperId() {
+			if ($this->blnUseWrapper) {
+				return $this->ControlId . '_ctl';
+			} else {
+				return $this->ControlId;
+			}
 		}
 
 		/**
@@ -1991,7 +2006,6 @@
 
 				// MISC
 				case "ControlId": return $this->strControlId;
-				case "WrapperId": return $this->strControlId . '_ctl';
 				case "Form": return $this->objForm;
 				case "ParentControl": return $this->objParentControl;
 

--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -2156,8 +2156,13 @@
 					}
 				case "Warning":
 					try {
-						$this->strWarning = QType::Cast($mixValue, QType::String);
-						$this->MarkAsModified(); // always modify, since it will get reset on subsequent drawing
+						if (is_string($mixValue) && trim($mixValue) === '') { // treat empty strings as nulls to prevent unnecessary drawing
+							$mixValue = null;
+						}
+						if ($this->strWarning !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->strWarning = $mixValue;
+							$this->MarkAsModified();
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
@@ -2166,8 +2171,13 @@
 
 				case "ValidationError":
 					try {
-						$this->strValidationError = QType::Cast($mixValue, QType::String);
-						$this->MarkAsModified(); // always modify, since it will get reset on subsequent drawing
+						if (is_string($mixValue) && trim($mixValue) === '') { // treat empty strings as nulls to prevent unnecessary drawing
+							$mixValue = null;
+						}
+						if ($this->strValidationError !== ($mixValue = QType::Cast($mixValue, QType::String))) {
+							$this->strValidationError = $mixValue;
+							$this->MarkAsModified();
+						}
 						break;
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();

--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -281,8 +281,9 @@
 
 			try {
 				$this->objForm->AddControl($this);
-				if ($this->objParentControl)
+				if ($this->objParentControl) {
 					$this->objParentControl->AddChildControl($this);
+				}
 			} catch (QCallerException $objExc) {
 				$objExc->IncrementOffset();
 				throw $objExc;

--- a/includes/base_controls/QDialogBase.class.php
+++ b/includes/base_controls/QDialogBase.class.php
@@ -444,7 +444,7 @@
 		 *
 		 */
 		public function Close() {
-			QApplication::ExecuteControlCommand($this->getJqControlId(), $this->getJqSetupFunction(), "close", QJsPriority::Final);
+			QApplication::ExecuteControlCommand($this->getJqControlId(), $this->getJqSetupFunction(), "close", QJsPriority::Last);
 		}
 
 		/**

--- a/includes/base_controls/QFormBase.class.php
+++ b/includes/base_controls/QFormBase.class.php
@@ -969,8 +969,12 @@
 				$objControl->RemoveChildControls(true);
 
 				// Remove this control from the parent
-				if ($objControl->ParentControl)
-					$objControl->ParentControl->RemoveChildControl($strControlId, false);
+				if ($objControl->ParentControl) {
+					$objControl->ParentControl->RemoveChildControl($strControlId, false);	// will redraw the ParentControl
+				} else {
+					// if the parent is the form, then remove it from the dom through javascript, since the form won't be redrawn
+					QApplication::ExecuteSelectorFunction('#' . $objControl->GetWrapperId(), 'remove');
+				}
 
 				// Remove this control
 				unset($this->objControlArray[$strControlId]);

--- a/includes/base_controls/QListBoxBase.class.php
+++ b/includes/base_controls/QListBoxBase.class.php
@@ -188,7 +188,6 @@
 				}
 			}
 
-			$this->ValidationError = null;
 			return true;
 		}
 

--- a/includes/base_controls/_enumerations.inc.php
+++ b/includes/base_controls/_enumerations.inc.php
@@ -235,6 +235,7 @@
 		const CommandsHigh = 'commandsHigh';
 		const CommandsMedium = 'commands';
 		const CommandsLow = 'commandsLow';
+		const CommandsFinal = 'commandsFinal';	// execute after all ajax commands, and resultant ajax commands have executed
 		const RegC = 'regc'; // register control list
 		const Html = 'html';
 		const Value = 'value';

--- a/includes/codegen/templates/db_orm/dialogs/_edit_dlg_subclass.tpl.php
+++ b/includes/codegen/templates/db_orm/dialogs/_edit_dlg_subclass.tpl.php
@@ -40,7 +40,7 @@ class <?= $strPropertyName ?>EditDlg extends <?= $strPropertyName ?>EditDlgGen {
 	 * @throws Exception
 	 * @throws QCallerException
 	 */
-	public function __construct($objParent, $strControlId = null) {
+	public function __construct($objParent = null, $strControlId = null) {
 		parent::__construct($objParent, $strControlId);
 
 		/**

--- a/includes/codegen/templates/db_orm/dialogs/dlg_constructor.tpl.php
+++ b/includes/codegen/templates/db_orm/dialogs/dlg_constructor.tpl.php
@@ -4,7 +4,7 @@
 	 * @throws Exception
 	 * @throws QCallerException
 	 */
-	public function __construct($objParentObject, $strControlId = null) {
+	public function __construct($objParentObject = null, $strControlId = null) {
 		try {
 			parent::__construct($objParentObject, $strControlId);
 		} catch (QCallerException $objExc) {

--- a/includes/framework/QApplicationBase.class.php
+++ b/includes/framework/QApplicationBase.class.php
@@ -991,7 +991,7 @@
 				QApplication::$JavascriptExclusiveCommand = ['selector'=>$mixSelector, 'func'=>$strFunctionName, 'params'=>$args];
 				return;
 			}
-			elseif ($args && end($args) === QJsPriority::Final) {
+			elseif ($args && end($args) === QJsPriority::Last) {
 				array_pop($args);
 				QApplication::$JavascriptCommandArray[QAjaxResponse::CommandsFinal][] = ['selector'=>$mixSelector, 'func'=>$strFunctionName, 'params'=>$args, 'final'=>true];
 				return;
@@ -1422,9 +1422,7 @@
 		/** Execute ONLY this command and exclude all others */
 		const Exclusive = '*jsExclusive*';
 		/** Execute this command after all ajax commands have been completely flushed */
-		const Final = '*jsFinal*';
-
-
+		const Last = '*jsFinal*';
 	}
 
 	/**

--- a/includes/framework/QApplicationBase.class.php
+++ b/includes/framework/QApplicationBase.class.php
@@ -990,7 +990,13 @@
 				array_pop($args);
 				QApplication::$JavascriptExclusiveCommand = ['selector'=>$mixSelector, 'func'=>$strFunctionName, 'params'=>$args];
 				return;
-			} else {
+			}
+			elseif ($args && end($args) === QJsPriority::Final) {
+				array_pop($args);
+				QApplication::$JavascriptCommandArray[QAjaxResponse::CommandsFinal][] = ['selector'=>$mixSelector, 'func'=>$strFunctionName, 'params'=>$args, 'final'=>true];
+				return;
+			}
+			else {
 				$code = QAjaxResponse::CommandsMedium;
 			}
 			if (empty($args)) {
@@ -1258,6 +1264,10 @@
 				$scripts = array_merge ($scripts, QApplication::$JavascriptCommandArray[QAjaxResponse::CommandsLow]);
 				unset (QApplication::$JavascriptCommandArray[QAjaxResponse::CommandsLow]);
 			}
+			if (!empty(QApplication::$JavascriptCommandArray[QAjaxResponse::CommandsFinal])) {
+				$scripts = array_merge ($scripts, QApplication::$JavascriptCommandArray[QAjaxResponse::CommandsFinal]);
+				unset (QApplication::$JavascriptCommandArray[QAjaxResponse::CommandsFinal]);
+			}
 			if ($scripts) {
 				QApplication::$JavascriptCommandArray[QAjaxResponse::CommandsMedium] = $scripts;
 			}
@@ -1411,6 +1421,9 @@
 		const Low = '*jsLow*';
 		/** Execute ONLY this command and exclude all others */
 		const Exclusive = '*jsExclusive*';
+		/** Execute this command after all ajax commands have been completely flushed */
+		const Final = '*jsFinal*';
+
 
 	}
 


### PR DESCRIPTION
Makes a number of impovements and fixes some issues with dialogs:
- Allows dialogs to be created on the fly rather than needing to have it be in the form
- Fixes a probem where you couldn't trap the QDialog_CloseEvent because the dialog was already closed.
- Fixes unnecessary redraws when bringing a dialog on to the screen from a validating button.
- Adds a feature that lets you set an event that will execute after all other ajax actions are complete, even if some of those ajax actions create new ajax actions.