### PR TITLE
bugfix-OptimisticLockingIssues

### DIFF
--- a/assets/php/examples/mysql_innodb.sql
+++ b/assets/php/examples/mysql_innodb.sql
@@ -65,7 +65,7 @@ CREATE TABLE person_with_lock (
     id INTEGER UNSIGNED NOT NULL AUTO_INCREMENT,
     first_name VARCHAR(50) NOT NULL,
     last_name VARCHAR(50) NOT NULL,
-    sys_timestamp TIMESTAMP,
+    sys_timestamp TIMESTAMP NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT PK_person_with_lock PRIMARY KEY (id)
 ) ENGINE=InnoDB;
 

--- a/includes/codegen/templates/db_orm/dialogs/_edit_dlg.tpl.php
+++ b/includes/codegen/templates/db_orm/dialogs/_edit_dlg.tpl.php
@@ -41,4 +41,6 @@ class <?= $strPropertyName ?>EditDlgGen extends QDialog {
 
 <?php include ('dlg_button_click.tpl.php'); ?>
 
+<?php include ('dlg_save.tpl.php'); ?>
+
 }

--- a/includes/codegen/templates/db_orm/dialogs/dlg_button_click.tpl.php
+++ b/includes/codegen/templates/db_orm/dialogs/dlg_button_click.tpl.php
@@ -8,16 +8,16 @@
 	public function ButtonClick($strFormId, $strControlId, $strParameter) {
 		switch ($strParameter) {
 			case 'save':
-				$this->pnl<?= $strPropertyName ?>->Save();
+				$this->Save();
 				break;
 
 			case 'delete':
 				$this->pnl<?= $strPropertyName ?>->Delete();
+                $this->Close();
 				break;
 
 			case 'cancel':
-				// do nothing
-				break;
+                $this->Close();
+                break;
 		}
-		$this->Close();
 	}

--- a/includes/codegen/templates/db_orm/dialogs/dlg_create_buttons.tpl.php
+++ b/includes/codegen/templates/db_orm/dialogs/dlg_create_buttons.tpl.php
@@ -9,5 +9,5 @@
 			sprintf(QApplication::Translate('Are you SURE you want to DELETE this %s?'),  QApplication::Translate('<?= $strPropertyName ?>')),
 			array('class'=>'ui-button-left')
 		);
-		$this->AddAction(new QDialog_ButtonEvent(), new QAjaxControlAction($this, 'ButtonClick'));
+		$this->AddAction(new QDialog_ButtonEvent(0, null, null, true), new QAjaxControlAction($this, 'ButtonClick'));
 	}

--- a/includes/codegen/templates/db_orm/dialogs/dlg_save.tpl.php
+++ b/includes/codegen/templates/db_orm/dialogs/dlg_save.tpl.php
@@ -1,0 +1,35 @@
+   /**
+    * Process a click on the Save button.
+    */
+    protected function Save() {
+        try {
+		    $this->pnl<?= $strPropertyName ?>->Save();
+        }
+        catch (QOptimisticLockingException $e) {
+            $dlg = QDialog::Alert (
+                QApplication::Translate("Another user has changed the information while you were editing it. Would you like to overwrite their changes, or refresh the page and try editing again?"),
+                ["Refresh", "Overwrite"]);
+            $dlg->AddAction(new QDialog_ButtonEvent(0, null, null, true), new QAjaxControlAction($this, "dlgOptimisticLocking_ButtonEvent"));
+            return;
+        }
+        $this->Close();
+	}
+
+   /**
+    * An optimistic lock exception has fired and we have put a dialog on the screen asking the user what they want to do.
+    * The user can either overwrite the data, or refresh and start the edit process over.
+    *
+    * @param string $strFormId      The form id
+    * @param string $strControlId   The control id of the dialog
+    * @param string $btn            The text on the button
+    */
+    protected function dlgOptimisticLocking_ButtonEvent($strFormId, $strControlId, $btn) {
+        if ($btn == "Overwrite") {
+            $this->pnl<?= $strPropertyName ?>->Save(true);
+            $this->Form->GetControl($strControlId)->Close();
+            $this->Close();
+        } else { // Refresh
+            $this->Form->GetControl($strControlId)->Close();
+            $this->pnl<?= $strPropertyName ?>->Refresh(true);
+        }
+    }

--- a/includes/codegen/templates/db_orm/forms/edit_button_click.tpl.php
+++ b/includes/codegen/templates/db_orm/forms/edit_button_click.tpl.php
@@ -1,19 +1,76 @@
 	// Button Event Handlers
-
-	protected function btnSave_Click($strFormId, $strControlId, $strParameter) {
-		$this->pnl<?= $strPropertyName ?>->Save();
+   /**
+    * Process a click on the Save button.
+    *
+    * @param $strFormId
+    * @param $strControlId
+    * @param $strParameter
+    */
+    protected function btnSave_Click($strFormId, $strControlId, $strParameter) {
+        try {
+		    $this->pnl<?= $strPropertyName ?>->Save();
+        }
+        catch (QOptimisticLockingException $e) {
+            $dlg = QDialog::Alert (
+                QApplication::Translate("Another user has changed the information while you were editing it. Would you like to overwrite their changes, or refresh the page and try editing again?"),
+                ["Refresh", "Overwrite"]);
+            $dlg->AddAction(new QDialog_ButtonEvent(0, null, null, true), new QAjaxAction("dlgOptimisticLocking_ButtonEvent"));
+            return;
+        }
 		$this->RedirectToListPage();
 	}
 
+   /**
+    * An optimistic lock exception has fired and we have put a dialog on the screen asking the user what they want to do.
+    * The user can either overwrite the data, or refresh and start the edit process over.
+    *
+    * @param string $strFormId      The form id
+    * @param string $strControlId   The control id of the dialog
+    * @param string $btn            The text on the button
+    */
+    protected function dlgOptimisticLocking_ButtonEvent($strFormId, $strControlId, $btn) {
+        if ($btn == "Overwrite") {
+            $this->pnl<?= $strPropertyName ?>->Save(true);
+            $this->GetControl($strControlId)->Close();
+            $this->RedirectToListPage();
+        } else { // Refresh
+            $this->GetControl($strControlId)->Close();
+            $this->pnl<?= $strPropertyName ?>->Refresh(true);
+        }
+    }
+
+   /**
+    * Process a click of the delete button.
+    *
+    * @param string $strFormId      The form id
+    * @param string $strControlId   The control id of the dialog
+    * @param string $strParameter   The control parameter, not used
+    */
 	protected function btnDelete_Click($strFormId, $strControlId, $strParameter) {
 		$this->pnl<?= $strPropertyName ?>->Delete();
 		$this->RedirectToListPage();
 	}
 
+   /**
+    * Process a click of the cancel button.
+    *
+    * @param string $strFormId      The form id
+    * @param string $strControlId   The control id of the dialog
+    * @param string $strParameter   The control parameter, not used
+    */
 	protected function btnCancel_Click($strFormId, $strControlId, $strParameter) {
 		$this->RedirectToListPage();
 	}
 
+   /**
+    * The user has pressed one of the buttons, and now wants to go back to the list page.
+    * Override this if you have another way of going to the list page.
+    *
+    * @param string $strFormId      The form id
+    * @param string $strControlId   The control id of the dialog
+    * @param string $strParameter   The control parameter, not used
+    */
 	protected function RedirectToListPage() {
-		QApplication::Redirect(__VIRTUAL_DIRECTORY__ . __FORMS__ . '/<?= QConvertNotation::UnderscoreFromCamelCase($objTable->ClassName) ?>_list.php');
+		QApplication::Redirect(__VIRTUAL_DIRECTORY__ . __FORMS__ . '/<?= QConvertNotation::UnderscoreFromCamelCase($objTable->ClassName) ?>_list.php',
+            false); // Putting false here is important to preventing an optimistic locking exception as a result of the user pressing the back button on the browser
 	}

--- a/includes/codegen/templates/db_orm/panels/_edit_base.tpl.php
+++ b/includes/codegen/templates/db_orm/panels/_edit_base.tpl.php
@@ -34,6 +34,8 @@ class <?= $strPropertyName ?>EditPanelGen extends QPanel {
 
 <?php include("edit_load.tpl.php"); ?>
 
+<?php include("edit_refresh.tpl.php"); ?>
+
 <?php include("edit_save.tpl.php"); ?>
 
 <?php include("edit_delete.tpl.php"); ?>

--- a/includes/codegen/templates/db_orm/panels/edit_load.tpl.php
+++ b/includes/codegen/templates/db_orm/panels/edit_load.tpl.php
@@ -15,3 +15,4 @@
 			QApplication::DisplayAlert(QApplication::Translate('Could not load the record. Perhaps it was deleted? Try again.'));
 		}
 	}
+

--- a/includes/codegen/templates/db_orm/panels/edit_refresh.tpl.php
+++ b/includes/codegen/templates/db_orm/panels/edit_refresh.tpl.php
@@ -1,0 +1,9 @@
+	/**
+     * Refresh the objects in the panel, optionally loading from saved data in the database.
+     *
+     * @param boolean $blnReload
+	 **/
+	public function Refresh ($blnReload = false) {
+        $this->mct<?= $strPropertyName  ?>->Refresh($blnReload);
+	}
+

--- a/includes/codegen/templates/db_orm/panels/edit_save.tpl.php
+++ b/includes/codegen/templates/db_orm/panels/edit_save.tpl.php
@@ -1,3 +1,3 @@
-	public function Save() {
-		$this->mct<?= $strPropertyName ?>->Save<?= $strPropertyName ?>();
+	public function Save($blnForceUpdate = false) {
+		$this->mct<?= $strPropertyName ?>->Save<?= $strPropertyName ?>($blnForceUpdate);
 	}

--- a/install/project/includes/controls/QWatcher.class.php
+++ b/install/project/includes/controls/QWatcher.class.php
@@ -5,42 +5,39 @@
  *
  * To select the type of cache used, change the class that QWatcher extends from.
  * QWatcherDB is based on a standard SQL database. See QWatcherDB.class.php for details on setup.
- * QWatcherAPC is uses the php APC or APCu cache, which requires a PECL installation.
+ * QWatcherCache uses one of the QCacheProvider subclasses, which allow you to use Redis, APC or MemCache for example.
  *
  * Once you configure the QWatcher subclass, to use the QWatcher system, do the following:
- * 1) At the top of each model file that you want to watch, (project/includes/model/*) set $blnWatchChanges to true.
- * 2) During the creation of a control that needs to watch a database table, call $ctl->Watch($dbNode), where
+ * During the creation of a control that needs to watch a database table, call $ctl->Watch($dbNode), where
  *    $dbNode is the node that represents the table you want to watch. For example, to have a datagrid watch the
- *    people table, call:
+ *    People table for changes, call:
  *   $dtg->Watch (QQN::People());
  *
  * That's it. From then on, when the system detects a change in the watched tables, the watching controls will automatically
- * redraw. Even controls in other windows will automatically redraw.
+ * redraw. Even controls in other windows or other browsers will automatically redraw.
  *
- * Note that a control can watch multiple tables by calling Watch multiple times, and if given a node chain
+ * A control can watch multiple tables by calling Watch multiple times, and if given a node chain
  * (like QQN::Project()->ProjectAsManager->etc.), it will watch all the tables in the chain.
  *
  * Detection currently happens on any ajax call. You can use QJsTimer to force periodic ajax calls if needed, or
  * just let the user's activity generate periodic ajax calls. A more advanced system would be to use a WebSocket server,
- * Socket.IO or something similar, but these things require server configurations that are currently beyond the scope
- * of QCubed.
+ * Socket.IO, a messaging server like PubNub or Google Messages or something similar, but these things require
+ * configurations that are currently beyond the scope of QCubed.
  */
 
 
-// To make the Watcher example code work, we need to create a kind of hack version of a watcher for the QCubed website.
-// Feel free to remove the example code.
-if (defined("__IN_EXAMPLE__")) {
-	class QWatcher extends QWatcherCache
+// This default watcher allows the user's browser to watch events, but not other browsers.
+// You SHOULD change this to get the full power of the watcher system. Either subclass the QWatcherDB class,
+// or use one of the persistent memory caches.
+class QWatcher extends QWatcherCache
+{
+	static protected function initCache()
 	{
-		static protected function initCache()
-		{
-			// Overrides the default version to create our own cache provider just for watchers. If you don't want to
-			// use the QApplication's $objCacheProvider, you can do this in your own code too.
-			static::$objCache = new QCacheProviderLocalMemory(['KeepInSession' => true]);
-		}
+		static::$objCache = new QCacheProviderLocalMemory(['KeepInSession' => true]);
+		//or, static::$objCache = new QCacheProviderAPC();
+		//or, static::$objCache = new QCacheProviderMemCache(['host'=>'myhost', ...]);
+		//or, static::$objCache = new QCacheProviderRedis(['parameters'=>[params...], 'options'=>[opts...]]);
 	}
-} else {
-	//class QWatcher extends QWatcherCache {}
-	//class QWatcher extends QWatcherDB {}
-	class QWatcher extends QWatcherNone {}
 }
+
+//or, class QWatcher extends QWatcherDB {}


### PR DESCRIPTION
For too long has QCubed issued optimistic locking errors for back button presses on the browser, or multiple people editing a record.

This fix does the following:
- Puts dialogs in to the codegenned forms and dialogs to correctly detect optimistic locking errors and asks users what to do when a record has changed that the user is editing.
- Prevents the Back button on the browser from causing an Optimistic Locking error by making sure changes are posted to the form before proceeding to the next page. 
- Fixes examples page to work
- Fixes the default QWatcher to work on initial installation, which is needed for forms that use a dialog to do edits.
- Wraps Update code in transactions in situations where an update requires changes to multiple tables. This prevents data corruption and missing optimistic locks when multiple users are updating the same record.