### PR TITLE
Bugfix-TableGenError

### DIFF
--- a/includes/codegen/QDatabaseCodeGen.class.php
+++ b/includes/codegen/QDatabaseCodeGen.class.php
@@ -84,7 +84,7 @@
 				return $this->objTableArray[$strTableName];
 			if (array_key_exists($strTableName, $this->objTypeTableArray)) 
 				return $this->objTypeTableArray[$strTableName];;	// deal with table special
-			throw new QCallerException(sprintf('Table does not exist or does not have a defined Primary Key: %s', $strTableName));
+			throw new QCallerException(sprintf('Table does not exist or could not be processed: %s. %s', $strTableName, $this->strErrors));
 		}
 
 		public function GetColumn($strTableName, $strColumnName) {


### PR DESCRIPTION
Fixing error message that incorrectly reported a problem with an index. Any number of issues with a table would cause it to not get included in the code generation, which would cause thrown exceptions instead of simple error messages in the output. This fix adds the error messages to the thrown exception so the user knows exactly why code generation could not proceed.