### PR TITLE
bugfix-RemoveQueryBuilderDependency

### DIFF
--- a/includes/codegen/templates/db_orm/class_gen/instantiation_methods.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/instantiation_methods.tpl.php
@@ -289,14 +289,8 @@
 			if (!$objDbRow) return null;
 
 			// We need the Column Aliases
-			$strColumnAliasArray = $objDbResult->QueryBuilder->ColumnAliasArray;
+			$strColumnAliasArray = $objDbResult->ColumnAliasArray;
 			if (!$strColumnAliasArray) $strColumnAliasArray = array();
-
-			// Pull Expansions
-			$objExpandAsArrayNode = $objDbResult->QueryBuilder->ExpandAsArrayNode;
-			if (!empty ($objExpandAsArrayNode)) {
-				throw new QCallerException ("Cannot use InstantiateCursor with ExpandAsArray");
-			}
 
 			// Load up the return result with a row and return it
 			return <?= $objTable->ClassName ?>::InstantiateDbRow($objDbRow, null, null, null, $strColumnAliasArray);

--- a/includes/framework/QDatabaseBase.class.php
+++ b/includes/framework/QDatabaseBase.class.php
@@ -1043,9 +1043,8 @@
 	 * @property QQueryBuilder $QueryBuilder
 	 */
 	abstract class QDatabaseResultBase extends QBaseClass {
-		// Allow to attach a QQueryBuilder object to use the result object as cursor resource for cursor queries.
-		/** @var QQueryBuilder Query builder object */
-		protected $objQueryBuilder;
+		/** @var array The column alias array. This is needed for instantiating cursors. */
+		protected $strColumnAliasArray;
 
 		/**
 		 * Fetches one row as indexed (column=>value style) array from the result set
@@ -1081,8 +1080,8 @@
 		 */
 		public function __get($strName) {
 			switch ($strName) {
-				case 'QueryBuilder':
-					return $this->objQueryBuilder;
+				case 'ColumnAliasArray':
+					return $this->strColumnAliasArray;
 				default:
 					try {
 						return parent::__get($strName);
@@ -1095,9 +1094,9 @@
 
 		public function __set($strName, $mixValue) {
 			switch ($strName) {
-				case 'QueryBuilder':
+				case 'ColumnAliasArray':
 					try {
-						return ($this->objQueryBuilder = QType::Cast($mixValue, 'QQueryBuilder'));
+						return ($this->strColumnAliasArray = QType::Cast($mixValue, QType::ArrayType));
 					} catch (QInvalidCastException $objExc) {
 						$objExc->IncrementOffset();
 						throw $objExc;

--- a/includes/framework/QModelTrait.trait.php
+++ b/includes/framework/QModelTrait.trait.php
@@ -268,11 +268,17 @@ trait QModelTrait {
 			throw $objExc;
 		}
 
+		// Pull Expansions
+		$objExpandAsArrayNode = $objQueryBuilder->ExpandAsArrayNode;
+		if (!empty ($objExpandAsArrayNode)) {
+			throw new QCallerException ("Cannot use QueryCursor with ExpandAsArray");
+		}
+
 		// Perform the query
 		$objDbResult = $objQueryBuilder->Database->Query($strQuery);
 
-		// Return the results cursor
-		$objDbResult->QueryBuilder = $objQueryBuilder;
+		// Get the alias array so we know how to instantiate a row from the result
+		$objDbResult->ColumnAliasArray = $objQueryBuilder->ColumnAliasArray;
 		return $objDbResult;
 	}
 

--- a/includes/tests/qcubed-unit/BasicOrmTest.php
+++ b/includes/tests/qcubed-unit/BasicOrmTest.php
@@ -102,6 +102,18 @@ class BasicOrmTests extends QUnitTestCaseBase {
 		
 		$this->assertEquals(3, $intItemCount2);
 	}
+
+	public function testQueryCursor() {
+		$objResult = Person::QueryCursor(
+			QQ::All(),
+			[QQ::OrderBy(QQN::Person()->FirstName)]
+		);
+
+		$objPerson = Person::InstantiateCursor($objResult);
+		$this->assertEquals("Alex", $objPerson->FirstName);
+		$objPerson = Person::InstantiateCursor($objResult);
+		$this->assertEquals("Ben", $objPerson->FirstName);
+	}
 	
 	public function testOrderByCondition() {
 		$objItems = Person::QueryArray(
@@ -146,7 +158,7 @@ class BasicOrmTests extends QUnitTestCaseBase {
 				QQ::OrderBy(QQN::Person()->LastName, QQN::Person()->FirstName)
 			)
 		);
-		
+
 		$arrNamesOnly = array();
 		foreach ($objPersonArray as $item) {
 			$arrNamesOnly[] = $item->FirstName . " " . $item->LastName;


### PR DESCRIPTION
Removes the dependency in the database adapters on the query builder. This is an important step to being able to move the database adapters to their own repository. Also adds a basic unit test for querying cursors.