### PR TITLE
Cleaning up the QDbBackedSessionHandler

### DIFF
--- a/includes/framework/QDbBackedSessionHandler.class.php
+++ b/includes/framework/QDbBackedSessionHandler.class.php
@@ -59,7 +59,7 @@
 		protected static $strSessionName	= ''; //PHPSESSID on a default PHP installation
 		
 		/** @var bool Whether to base64 the session data. Required when storing data in a TEXT field. */
-		public static $blnBase64			= false;
+		public static $blnBase64			= true;
 
 		/** @var bool Whether to compress the session data. */
 		public static $blnCompress			= true;

--- a/includes/framework/QDbBackedSessionHandler.class.php
+++ b/includes/framework/QDbBackedSessionHandler.class.php
@@ -11,7 +11,34 @@
 	 *  data - can be a BLOB or BINARY or VARBINARY or a TEXT. If TEXT, be sure to leave $blnBase64 on. If you are using
 	 * 		a binary field, you can turn that off to save space. Make sure your column is capable of holding the maximum size of
 	 * 		session data for your app, which depends on what you are putting in the $_SESSION variable.
+	 * 
+	 * Below is an example SQL you can use. Make sure you add a PRIMARY KEY on ID and an INDEX on last_access_time
 	 *
+	 *	CREATE TABLE `qc_session` (
+	 *		`id` CHAR(42) NOT NULL DEFAULT '',
+	 *		`last_access_time` int(10) UNSIGNED NOT NULL DEFAULT 0,
+	 *		`data` BLOB NOT NULL DEFAULT ''
+	 *	) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci; 
+	 *  ALTER TABLE `qc_session` ADD PRIMARY KEY(`id`);
+	 *  ALTER TABLE `qc_session` ADD INDEX `in_qcsession_last_access_time` (`last_access_time`);
+	 *
+	 *  A little more information. on the "id" column. 
+	 *  Column id stores the session id which can be of a different length in your specific installation. It is formed by concatenating the session_name(), a dot(.) and the session_id().
+	 *  session_name is by default PHPSESSID=> length 9CHARS
+	 *  a dot . => 1 CHARS
+	 *	session_id => 32 CHARS (by default)
+	 *	BUT:
+	 *   In PHP < 7:
+	 *		By default, PHP session_id's are MD5 strings => 32CHARS.
+	 *		However if you set session.hash_function to 1, this session_id will be SHA1 => 40CHARS
+	 *	 In PHP7:
+	 *		The length of the session is determined by session.sid_length. Default 32 => 32CHARS.
+         *
+	 *	  Also check http://php.net/manual/en/function.session-id.php
+	 *
+	 *	  So as an example: PHPSESSID.6e80a2fb32a996539874f96b6ba460f7 will be 9 + 1 + 32 = 42CHARS -> Column has to be CHAR(42).
+	 * 
+	 * 
 	 * @package Sessions
 	 */
 	class QDbBackedSessionHandler extends QBaseClass {
@@ -29,13 +56,13 @@
 		/**
 		 * @var string The session name to be used for saving sessions.
 		 */
-		protected static $strSessionName = '';
+		protected static $strSessionName	= ''; //PHPSESSID on a default PHP installation
 		
 		/** @var bool Whether to base64 the session data. Required when storing data in a TEXT field. */
-		public static $blnBase64 = true;
+		public static $blnBase64			= false;
 
 		/** @var bool Whether to compress the session data. */
-		public static $blnCompress = true;
+		public static $blnCompress			= true;
 
 
 		/**
@@ -48,17 +75,18 @@
 		 * @throws Exception|QCallerException|QInvalidCastException
 		 */
 		public static function Initialize($intDbIndex = 1, $strTableName = "qc_session") {
-			self::$intDbIndex = QType::Cast($intDbIndex, QType::Integer);
+			self::$intDbIndex	= QType::Cast($intDbIndex, QType::Integer);
 			self::$strTableName = QType::Cast($strTableName, QType::String);
 			// If the database index exists
-			if (!array_key_exists(self::$intDbIndex, QApplication::$Database)) {
+			if (!isset(QApplication::$Database[self::$intDbIndex]) ) {
 				throw new QCallerException('No database defined at DB_CONNECTION index ' . self::$intDbIndex . '. Correct your settings in configuration.inc.php.');
 			}
-			$objDatabase = QApplication::$Database[self::$intDbIndex];
-			// see if the database contains a table with desired name
-			if (!in_array(self::$strTableName, $objDatabase->GetTables())) {
-				throw new QCallerException('Table ' . self::$strTableName . ' not found in database at DB_CONNECTION index ' . self::$intDbIndex . '. Correct your settings in configuration.inc.php.');
-			}
+// We don't want a GetTables everytime I do a request. This will slow the overal system down. Yes, it will crash in a slighty less clear way, does this matter?
+//			$objDatabase = QApplication::$Database[self::$intDbIndex];
+//			// see if the database contains a table with desired name
+//			if (!in_array(self::$strTableName, $objDatabase->GetTables())) {
+//				throw new QCallerException('Table ' . self::$strTableName . ' not found in database at DB_CONNECTION index ' . self::$intDbIndex . '. Correct your settings in configuration.inc.php.');
+//			}
 			// Set session handler functions
 			$session_ok = session_set_save_handler(
 				'QDbBackedSessionHandler::SessionOpen',
@@ -101,29 +129,29 @@
 
 		/**
 		 * Read the session data (used by PHP when the session handler is active)
-		 * @param string $id
+		 * @param string $strSessionId
 		 *
 		 * @return string the session data, base64 decoded
 		 * @throws QCallerException
 		 */
-		public static function SessionRead($id) {
-			$id = self::$strSessionName . '.' . $id;
-			$objDatabase = QApplication::$Database[self::$intDbIndex];
-			$query = '
+		public static function SessionRead($strSessionId) {
+			$objDatabase	= QApplication::$Database[self::$intDbIndex];
+			$query			= '
 				SELECT
 					' . $objDatabase->EscapeIdentifier('data') . '
 				FROM
 					' . $objDatabase->EscapeIdentifier(self::$strTableName) . '
 				WHERE
-					' . $objDatabase->EscapeIdentifier('id') . ' = ' . $objDatabase->SqlVariable($id);
+					' . $objDatabase->EscapeIdentifier('id') . ' = ' . $objDatabase->SqlVariable(self::GetFullSessionId($strSessionId));
 
 			$result = $objDatabase->Query($query);
 
 			$result_row = $result->FetchRow();
 
 
-			if (!$result_row) // either the data was empty or the row was not found
+			if (!$result_row) { // either the data was empty or the row was not found
 				return '';
+			}
 			$strData = $result_row[0];
 
 			/** A kludge to fix a particular problem. Would require a complete rewrite of our database adapters to do this right. */
@@ -135,8 +163,9 @@
 				}
 			}
 
-			if (!$strData)
+			if (!$strData) {
 				return '';
+			}
 
 			if (self::$blnBase64) {
 				$strData = base64_decode($strData);
@@ -166,23 +195,22 @@
 
 		/**
 		 * Tells whether a session by given name exists or not (used by PHP when the session handler is active)
-		 * @param string $id Session ID
+		 * @param string $strSessionId Session ID
 		 *
 		 * @return bool does the session exist or not
 		 */
-		public static function SessionExists($id) {
-			$id = self::$strSessionName . '.' . $id;
-			$objDatabase = QApplication::$Database[self::$intDbIndex];
-			$query = '
+		public static function SessionExists($strSessionId) {
+			$objDatabase	= QApplication::$Database[self::$intDbIndex];
+			$query			= '
 				SELECT 1
 				FROM
 					' . $objDatabase->EscapeIdentifier(self::$strTableName) . '
 				WHERE
-					' . $objDatabase->EscapeIdentifier('id') . ' = ' . $objDatabase->SqlVariable($id);
+					' . $objDatabase->EscapeIdentifier('id') . ' = ' . $objDatabase->SqlVariable(self::GetFullSessionId($strSessionId));
 
-			$result = $objDatabase->Query($query);
+			$result			= $objDatabase->Query($query);
 
-			$result_row = $result->FetchArray();
+			$result_row		= $result->FetchArray();
 
 			// either the data was empty or the row was not found
 			return !empty($result_row);
@@ -191,14 +219,14 @@
 		/**
 		 * Write data to the session
 		 *
-		 * @param string $id The session ID
+		 * @param string $strSessionId The session ID
 		 * @param string $strSessionData Data to be written to the Session whose ID was supplied
 		 *
 		 * @return bool
 		 */
-		public static function SessionWrite($id, $strSessionData) {
+		public static function SessionWrite($strSessionId, $strSessionData) {
 			if (empty($strSessionData)) {
-				static::SessionDestroy($id);
+				static::SessionDestroy($strSessionId);
 				return true;
 			}
 
@@ -210,7 +238,7 @@
 
 			if (defined('DB_BACKED_SESSION_HANDLER_ENCRYPTION_KEY')) {
 				try {
-					$crypt = new QCryptography(DB_BACKED_SESSION_HANDLER_ENCRYPTION_KEY, false, null, DB_BACKED_SESSION_HANDLER_HASH_KEY);
+					$crypt		= new QCryptography(DB_BACKED_SESSION_HANDLER_ENCRYPTION_KEY, false, null, DB_BACKED_SESSION_HANDLER_HASH_KEY);
 					$strEncoded = $crypt->Encrypt($strEncoded);
 				}
 				catch(Exception $e) {
@@ -229,14 +257,13 @@
 
 			assert (!empty($strEncoded));
 
-			$id = self::$strSessionName . '.' . $id;
-			$objDatabase = QApplication::$Database[self::$intDbIndex];
+			$objDatabase	= QApplication::$Database[self::$intDbIndex];
 			$objDatabase->InsertOrUpdate(
 				self::$strTableName,
 				array(
-					'data' => $strEncoded,
-					'last_access_time' => time(),
-					'id' => $id
+					'data'				=> $strEncoded,
+					'last_access_time'	=> time(),
+					'id'				=> self::GetFullSessionId($strSessionId)
 				),
 				'id');
 			return true;
@@ -245,18 +272,17 @@
 		/**
 		 * Destroy the session for a given session ID
 		 *
-		 * @param string $id The session ID
+		 * @param string $strSessionId The session ID
 		 *
 		 * @return bool
 		 */
-		public static function SessionDestroy($id) {
-			$id = self::$strSessionName . '.' . $id;
-			$objDatabase = QApplication::$Database[self::$intDbIndex];
-			$query = '
+		public static function SessionDestroy($strSessionId) {
+			$objDatabase	= QApplication::$Database[self::$intDbIndex];
+			$query			= '
 				DELETE FROM
 					' . $objDatabase->EscapeIdentifier(self::$strTableName) . '
 				WHERE
-					' . $objDatabase->EscapeIdentifier('id') . ' = ' . $objDatabase->SqlVariable($id);
+					' . $objDatabase->EscapeIdentifier('id') . ' = ' . $objDatabase->SqlVariable(self::GetFullSessionId($strSessionId));
 
 			$objDatabase->NonQuery($query);
 			return true;
@@ -270,10 +296,10 @@
 		 * @return bool
 		 */
 		public static function SessionGarbageCollect($intMaxSessionLifetime) {
-			$objDatabase = QApplication::$Database[self::$intDbIndex];
-			$old = time() - $intMaxSessionLifetime;
+			$objDatabase	= QApplication::$Database[self::$intDbIndex];
+			$old			= time() - $intMaxSessionLifetime;
 
-			$query = '
+			$query			= '
 				DELETE FROM
 					' . $objDatabase->EscapeIdentifier(self::$strTableName) . '
 				WHERE
@@ -281,5 +307,15 @@
 
 			$objDatabase->NonQuery($query);
 			return true;
+		}
+		
+		/**
+		 * Concatenates the session_name with the session_id
+		 * 
+		 * @param string $strSessionId
+		 * @return string
+		 */
+		private static function GetFullSessionId($strSessionId) {
+			return self::$strSessionName.'.'.$strSessionId;
 		}
 	}


### PR DESCRIPTION
I needed this at work so I cleaned it up a bit. It was written in 2012 and was missing some documentation.
I added an example SQL CREATE statement for the database which makes it easier for users to get started with it.
I also removed the GetTables() in the Initialize because I don't think it's a good idea to do this every single request. It will crash anyway, and a database table won't just disappear...

I also moved the concatenation of the session_name with the session_id to a seperate function.

Let me know if this is ok.