### PR TITLE
bugfix-AjaxJsAndCsIncludes

### DIFF
--- a/includes/base_controls/QFormBase.class.php
+++ b/includes/base_controls/QFormBase.class.php
@@ -1572,8 +1572,9 @@
 				}
 			}
 
-			if (count($strArrayToReturn))
+			if (count($strArrayToReturn)) {
 				return $strArrayToReturn;
+			}
 
 			return null;
 		}
@@ -1607,8 +1608,9 @@
 						}
 			}
 
-			if (count($strArrayToReturn))
+			if (count($strArrayToReturn)) {
 				return $strArrayToReturn;
+			}
 
 			return null;
 		}
@@ -1841,7 +1843,7 @@
 
 			// put javascript environment defines up early for use by other js files.
 			$strHtml .= '<script type="text/javascript">' .
-				sprintf('qc.baseDir = "%s"; ', __VIRTUAL_DIRECTORY__ . __SUBDIRECTORY__) .
+				sprintf('qc.baseDir = "%s"; ', __VIRTUAL_DIRECTORY__) .
 				sprintf('qc.jsAssets = "%s"; ', __VIRTUAL_DIRECTORY__ . __JS_ASSETS__) .
 				sprintf('qc.phpAssets = "%s"; ', __VIRTUAL_DIRECTORY__ . __PHP_ASSETS__) .
 				sprintf('qc.cssAssets = "%s"; ', __VIRTUAL_DIRECTORY__ . __CSS_ASSETS__) .


### PR DESCRIPTION
We normally require file paths to be relative to DOCROOT. However, for ajax loaded files with absolute paths, we were adding in the __SUBDIRECTORY__ to qc.baseDir, causing these files to have the __SUBDIRECTORY__ twice.

Requires a change to QCKEditor.