### PR TITLE
bugfix-ModelGettersAndSetters

### DIFF
--- a/includes/codegen/templates/db_orm/class_gen/property_get.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/property_get.tpl.php
@@ -6,64 +6,7 @@
 		 * @return mixed
 		 */
 		public function __get($strName) {
-			// Use getter if it exists
-			$strMethod = 'get' . $strName;
-			if (method_exists($this, $strMethod)) {
-				return $this->$strMethod();
-			}
-
 			switch ($strName) {
-				///////////////////
-				// Member Objects
-				///////////////////
-<?php foreach ($objTable->ColumnArray as $objColumn) { ?>
-<?php if ($objColumn->Reference) { ?>
-<?php if (!$objColumn->Reference->IsType) { ?>
-				case '<?= $objColumn->Reference->PropertyName ?>':
-					/**
-					 * Gets the value of the <?= $objColumn->Reference->VariableType ?> object referenced by <?= $objColumn->VariableName ?> <?php if ($objColumn->Identity) print '(Read-Only PK)'; else if ($objColumn->PrimaryKey) print '(PK)'; else if ($objColumn->Unique) print '(Unique)'; else if ($objColumn->NotNull) print '(Not Null)'; ?>
-
-					 * @return <?= $objColumn->Reference->VariableType ?>
-
-					 */
-					try {
-						if ((!$this-><?= $objColumn->Reference->VariableName ?>) && (!is_null($this-><?= $objColumn->VariableName ?>)))
-							$this-><?= $objColumn->Reference->VariableName ?> = <?= $objColumn->Reference->VariableType ?>::Load($this-><?= $objColumn->VariableName ?>);
-						return $this-><?= $objColumn->Reference->VariableName ?>;
-					} catch (QCallerException $objExc) {
-						$objExc->IncrementOffset();
-						throw $objExc;
-					}
-<?php } ?>
-<?php } ?>
-<?php } ?>
-<?php foreach ($objTable->ReverseReferenceArray as $objReverseReference) { ?>
-<?php if ($objReverseReference->Unique) { ?>
-<?php $objReverseReferenceTable = $objCodeGen->TableArray[strtolower($objReverseReference->Table)]; ?>
-<?php $objReverseReferenceColumn = $objReverseReferenceTable->ColumnArray[strtolower($objReverseReference->Column)]; ?>
-				case '<?= $objReverseReference->ObjectPropertyName ?>':
-					/**
-					 * Gets the value of the <?= $objReverseReference->VariableType ?> object that uniquely references this <?= $objTable->ClassName ?>
-
-					 * by <?= $objReverseReference->ObjectMemberVariable ?> (Unique)
-					 * @return <?= $objReverseReference->VariableType ?>
-
-					 */
-					try {
-						if (!$this->__blnRestored ||
-								$this-><?= $objReverseReference->ObjectMemberVariable ?> === false)
-							// Either this is a new object, or we've attempted early binding -- and the reverse reference object does not exist
-							return null;
-						if (!$this-><?= $objReverseReference->ObjectMemberVariable ?>)
-							$this-><?= $objReverseReference->ObjectMemberVariable ?> = <?= $objReverseReference->VariableType ?>::LoadBy<?= $objReverseReferenceColumn->PropertyName ?>(<?= $objCodeGen->ImplodeObjectArray(', ', '$this->', '', 'VariableName', $objTable->PrimaryKeyColumnArray) ?>);
-						return $this-><?= $objReverseReference->ObjectMemberVariable ?>;
-					} catch (QCallerException $objExc) {
-						$objExc->IncrementOffset();
-						throw $objExc;
-					}
-
-<?php } ?>
-<?php } ?>
 
 				////////////////////////////
 				// Virtual Object References (Many to Many and Reverse References)
@@ -123,6 +66,12 @@
 
 				default:
 					try {
+        			    // Use getter if it exists
+                        $strMethod = 'get' . $strName;
+                        if (method_exists($this, $strMethod)) {
+                            return $this->$strMethod();
+                        }
+
 						return parent::__get($strName);
 					} catch (QCallerException $objExc) {
 						$objExc->IncrementOffset();

--- a/includes/codegen/templates/db_orm/class_gen/property_getters_setters.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/property_getters_setters.tpl.php
@@ -8,7 +8,9 @@
    /**
 	* Gets the value of <?= $objColumn->VariableName ?> <?php if ($objColumn->Identity) print '(Read-Only PK)'; else if ($objColumn->PrimaryKey) print '(PK)'; else if ($objColumn->Timestamp) print '(Read-Only Timestamp)'; else if ($objColumn->Unique) print '(Unique)'; else if ($objColumn->NotNull) print '(Not Null)'; ?>
 
+<?php if (!$objColumn->Identity) { ?>
 	* @throws QCallerException
+<?php } ?>
 	* @return <?= $objColumn->VariableType ?>
 
 	*/
@@ -31,6 +33,28 @@
 	}
 <?php } ?>
 
+<?php if ($objColumn->Reference && !$objColumn->Reference->IsType) { ?>
+
+    /**
+     * Gets the value of the <?= $objColumn->Reference->VariableType ?> object referenced by <?= $objColumn->VariableName ?> <?php if ($objColumn->Identity) print '(Read-Only PK)'; else if ($objColumn->PrimaryKey) print '(PK)'; else if ($objColumn->Unique) print '(Unique)'; else if ($objColumn->NotNull) print '(Not Null)'; ?>
+
+     * If the object is not loaded, will load the object (caching it) before returning it.
+     * @throws QCallerException
+     * @return <?= $objColumn->Reference->VariableType ?>
+
+     */
+     public function get<?= $objColumn->Reference->PropertyName ?>() {
+ 		if (empty($this->__blnValid[self::<?= strtoupper($objColumn->Name) ?>_FIELD])) {
+			throw new QCallerException("<?= $objColumn->PropertyName ?> has not been set nor was selected in the most recent query and is not valid.");
+		}
+        if ((!$this-><?= $objColumn->Reference->VariableName ?>) && (!is_null($this-><?= $objColumn->VariableName ?>))) {
+            $this-><?= $objColumn->Reference->VariableName ?> = <?= $objColumn->Reference->VariableType ?>::Load($this-><?= $objColumn->VariableName ?>);
+        }
+        return $this-><?= $objColumn->Reference->VariableName ?>;
+     }
+<?php } ?>
+
+
 <?php 	if ((!$objColumn->Identity) && (!$objColumn->Timestamp)) { ?>
 
    /**
@@ -39,13 +63,18 @@
 	* Returns $this to allow chaining of setters.
 	* @param <?= $objColumn->VariableType ?><?= $objColumn->NotNull ? '' : '|null' ?> $<?= $objColumn->VariableName ?>
 
+    * @throws QCallerException
 	* @return <?= $objTable->ClassName ?>
 
 	*/
 	public function set<?= $objColumn->PropertyName ?>($<?= $objColumn->VariableName ?>) {
 <?php if ($objColumn->NotNull) { ?>
         if ($<?= $objColumn->VariableName ?> === null) {
+<?php if (is_null($objColumn->Default)) { ?>
             throw new QCallerException('Cannot set <?= $objColumn->PropertyName ?> to null');
+<?php } else { ?>
+             $<?= $objColumn->VariableName ?> = static::<?= $objColumn->PropertyName ?>Default;
+<?php } ?>
         }
 <?php } ?>
 		$<?= $objColumn->VariableName ?> = QType::Cast($<?= $objColumn->VariableName ?>, <?= $objColumn->VariableTypeAsConstant ?>);
@@ -61,6 +90,98 @@
 		return $this; // allows chaining
 	}
 
+<?php       if (($objColumn->Reference) && (!$objColumn->Reference->IsType)) { ?>
+
+    /**
+     * Sets the value of the <?= $objColumn->Reference->VariableType ?> object referenced by <?= $objColumn->VariableName ?> <?php if ($objColumn->Identity) print '(Read-Only PK)'; else if ($objColumn->PrimaryKey) print '(PK)'; else if ($objColumn->Unique) print '(Unique)'; else if ($objColumn->NotNull) print '(Not Null)'; ?>
+
+     * @param null|<?= $objColumn->Reference->VariableType ?> $<?= $objColumn->Reference->VariableName ?>
+
+     * @throws QCallerException
+     * @return <?= $objTable->ClassName ?>
+
+     */
+    public function set<?= $objColumn->Reference->PropertyName ?>($<?= $objColumn->Reference->VariableName ?>) {
+        if (is_null($<?= $objColumn->Reference->VariableName ?>)) {
+            $this->set<?= $objColumn->PropertyName ?>(null);
+        } else {
+            $<?= $objColumn->Reference->VariableName ?> = QType::Cast($<?= $objColumn->Reference->VariableName ?>, '<?= $objColumn->Reference->VariableType ?>');
+
+            // Make sure its a SAVED <?= $objColumn->Reference->VariableType ?> object
+            if (is_null($<?= $objColumn->Reference->VariableName ?>-><?= $objCodeGen->TableArray[strtolower($objColumn->Reference->Table)]->ColumnArray[strtolower($objColumn->Reference->Column)]->PropertyName ?>)) {
+                throw new QCallerException('Unable to set an unsaved <?= $objColumn->Reference->PropertyName ?> for this <?= $objTable->ClassName ?>');
+            }
+
+            // Update Local Member Variables
+            $this->set<?= $objColumn->PropertyName ?>($<?= $objColumn->Reference->VariableName ?>->get<?= $objCodeGen->TableArray[strtolower($objColumn->Reference->Table)]->ColumnArray[strtolower($objColumn->Reference->Column)]->PropertyName ?>());
+            $this-><?= $objColumn->Reference->VariableName ?> = $<?= $objColumn->Reference->VariableName ?>;
+        }
+        return $this;
+    }
+<?php       } ?>
+
+
 <?php 	} ?>
 
 <?php } ?>
+
+<?php
+    // Unique reverse reference properties
+foreach ($objTable->ReverseReferenceArray as $objReverseReference) {
+	if ($objReverseReference->Unique) {
+		$objReverseReferenceTable = $objCodeGen->TableArray[strtolower($objReverseReference->Table)];
+		$objReverseReferenceColumn = $objReverseReferenceTable->ColumnArray[strtolower($objReverseReference->Column)]; ?>
+
+   /**
+    * Gets the value of the <?= $objReverseReference->VariableType ?> object that uniquely references this <?= $objTable->ClassName ?>
+
+    * by <?= $objReverseReference->ObjectMemberVariable ?> (Unique)
+    * Returns null if the object does not exist.
+    * @return null|<?= $objReverseReference->VariableType ?>
+
+    */
+    public function get<?= $objReverseReference->ObjectPropertyName ?>() {
+        if (!$this->__blnRestored ||
+            $this-><?= $objReverseReference->ObjectMemberVariable ?> === false) {
+            // Either this is a new object, or we've attempted early binding -- and the reverse reference object does not exist
+            return null;
+        }
+        if (!$this-><?= $objReverseReference->ObjectMemberVariable ?>) {
+            $this-><?= $objReverseReference->ObjectMemberVariable ?> = <?= $objReverseReference->VariableType ?>::LoadBy<?= $objReverseReferenceColumn->PropertyName ?>(<?= $objCodeGen->ImplodeObjectArray(', ', '$this->', '', 'VariableName', $objTable->PrimaryKeyColumnArray) ?>);
+        }
+        return $this-><?= $objReverseReference->ObjectMemberVariable ?>;
+    }
+
+   /**
+    * Sets the value of the <?= $objReverseReference->VariableType ?> object that uniquely references this <?= $objTable->ClassName ?>
+    * @param null|<?= $objReverseReference->VariableType ?> $<?= $objReverseReference->ObjectMemberVariable ?>
+
+    * by <?= $objReverseReference->ObjectMemberVariable ?> (Unique)
+    * @return <?= $objTable->ClassName ?>
+
+    */
+    public function set<?= $objReverseReference->ObjectPropertyName ?>($<?= $objReverseReference->ObjectMemberVariable ?>) {
+        if (is_null($<?= $objReverseReference->ObjectMemberVariable ?>)) {
+            $this-><?= $objReverseReference->ObjectMemberVariable ?> = null;
+
+            // Make sure we update the adjoined <?= $objReverseReference->VariableType ?> object the next time we call Save()
+            $this->blnDirty<?= $objReverseReference->ObjectPropertyName ?> = true;
+        } else {
+            $<?= $objReverseReference->ObjectMemberVariable ?> = QType::Cast($<?= $objReverseReference->ObjectMemberVariable ?>, '<?= $objReverseReference->VariableType ?>');
+
+            // Are we setting <?= $objReverseReference->ObjectMemberVariable ?> to a DIFFERENT $<?= $objReverseReference->ObjectMemberVariable ?>?
+            if ((!$this-><?= $objReverseReference->ObjectPropertyName ?>) || ($this-><?= $objReverseReference->ObjectPropertyName ?>-><?= $objCodeGen->GetTable($objReverseReference->Table)->PrimaryKeyColumnArray[0]->PropertyName ?> != $<?= $objReverseReference->ObjectMemberVariable ?>-><?= $objCodeGen->GetTable($objReverseReference->Table)->PrimaryKeyColumnArray[0]->PropertyName ?>)) {
+                // Yes -- therefore, set the "Dirty" flag to true
+                // to make sure we update the adjoined <?= $objReverseReference->VariableType ?> object the next time we call Save()
+                $this->blnDirty<?= $objReverseReference->ObjectPropertyName ?> = true;
+
+                // Update Local Member Variable
+                $this-><?= $objReverseReference->ObjectMemberVariable ?> = $<?= $objReverseReference->ObjectMemberVariable ?>;
+            }
+        }
+        return $this;
+    }
+
+
+<?php }
+} ?>

--- a/includes/codegen/templates/db_orm/class_gen/property_set.tpl.php
+++ b/includes/codegen/templates/db_orm/class_gen/property_set.tpl.php
@@ -7,104 +7,19 @@
 		 * @return mixed
 		 */
 		public function __set($strName, $mixValue) {
-			// Use setter if it exists
-			$strMethod = 'set' . $strName;
-			if (method_exists($this, $strMethod)) {
-				$this->$strMethod($mixValue);
-				return;
-			}
+            try {
 
-			switch ($strName) {
-				///////////////////
-				// Member Objects
-				///////////////////
-<?php foreach ($objTable->ColumnArray as $objColumn) { ?>
-<?php if (($objColumn->Reference) && (!$objColumn->Reference->IsType)) { ?>
-				case '<?= $objColumn->Reference->PropertyName ?>':
-					/**
-					 * Sets the value of the <?= $objColumn->Reference->VariableType ?> object referenced by <?= $objColumn->VariableName ?> <?php if ($objColumn->Identity) print '(Read-Only PK)'; else if ($objColumn->PrimaryKey) print '(PK)'; else if ($objColumn->Unique) print '(Unique)'; else if ($objColumn->NotNull) print '(Not Null)'; ?>
+                // Use setter if it exists
+                $strMethod = 'set' . $strName;
+                if (method_exists($this, $strMethod)) {
+                    $this->$strMethod($mixValue);
+                    return;
+                }
 
-					 * @param <?= $objColumn->Reference->VariableType ?> $mixValue
-					 * @return <?= $objColumn->Reference->VariableType ?>
+                return parent::__set($strName, $mixValue);
+            } catch (QCallerException $objExc) {
+                $objExc->IncrementOffset();
+                throw $objExc;
+            }
+        }
 
-					 */
-					if (is_null($mixValue)) {
-						$this->set<?= $objColumn->PropertyName ?>(null);
-						return null;
-					} else {
-						// Make sure $mixValue actually is a <?= $objColumn->Reference->VariableType ?> object
-						try {
-							$mixValue = QType::Cast($mixValue, '<?= $objColumn->Reference->VariableType ?>');
-						} catch (QInvalidCastException $objExc) {
-							$objExc->IncrementOffset();
-							throw $objExc;
-						}
-
-						// Make sure $mixValue is a SAVED <?= $objColumn->Reference->VariableType ?> object
-						if (is_null($mixValue-><?= $objCodeGen->TableArray[strtolower($objColumn->Reference->Table)]->ColumnArray[strtolower($objColumn->Reference->Column)]->PropertyName ?>))
-							throw new QCallerException('Unable to set an unsaved <?= $objColumn->Reference->PropertyName ?> for this <?= $objTable->ClassName ?>');
-
-						// Update Local Member Variables
-						$this->set<?= $objColumn->PropertyName ?>($mixValue-><?= $objCodeGen->TableArray[strtolower($objColumn->Reference->Table)]->ColumnArray[strtolower($objColumn->Reference->Column)]->PropertyName ?>);
-						$this-><?= $objColumn->Reference->VariableName ?> = $mixValue;
-
-						// Return $mixValue
-						return $mixValue;
-					}
-					break;
-
-<?php } ?>
-<?php } ?>
-<?php foreach ($objTable->ReverseReferenceArray as $objReverseReference) { ?>
-<?php if ($objReverseReference->Unique) { ?>
-				case '<?= $objReverseReference->ObjectPropertyName ?>':
-					/**
-					 * Sets the value of the <?= $objReverseReference->VariableType ?> object referenced by <?= $objReverseReference->ObjectMemberVariable ?> (Unique)
-					 * @param <?= $objReverseReference->VariableType ?> $mixValue
-					 * @return <?= $objReverseReference->VariableType ?>
-
-					 */
-					if (is_null($mixValue)) {
-						$this-><?= $objReverseReference->ObjectMemberVariable ?> = null;
-
-						// Make sure we update the adjoined <?= $objReverseReference->VariableType ?> object the next time we call Save()
-						$this->blnDirty<?= $objReverseReference->ObjectPropertyName ?> = true;
-
-						return null;
-					} else {
-						// Make sure $mixValue actually is a <?= $objReverseReference->VariableType ?> object
-						try {
-							$mixValue = QType::Cast($mixValue, '<?= $objReverseReference->VariableType ?>');
-						} catch (QInvalidCastException $objExc) {
-							$objExc->IncrementOffset();
-							throw $objExc;
-						}
-
-						// Are we setting <?= $objReverseReference->ObjectMemberVariable ?> to a DIFFERENT $mixValue?
-						if ((!$this-><?= $objReverseReference->ObjectPropertyName ?>) || ($this-><?= $objReverseReference->ObjectPropertyName ?>-><?= $objCodeGen->GetTable($objReverseReference->Table)->PrimaryKeyColumnArray[0]->PropertyName ?> != $mixValue-><?= $objCodeGen->GetTable($objReverseReference->Table)->PrimaryKeyColumnArray[0]->PropertyName ?>)) {
-							// Yes -- therefore, set the "Dirty" flag to true
-							// to make sure we update the adjoined <?= $objReverseReference->VariableType ?> object the next time we call Save()
-							$this->blnDirty<?= $objReverseReference->ObjectPropertyName ?> = true;
-
-							// Update Local Member Variable
-							$this-><?= $objReverseReference->ObjectMemberVariable ?> = $mixValue;
-						} else {
-							// Nope -- therefore, make no changes
-						}
-
-						// Return $mixValue
-						return $mixValue;
-					}
-					break;
-
-<?php } ?>
-<?php } ?>
-				default:
-					try {
-						return parent::__set($strName, $mixValue);
-					} catch (QCallerException $objExc) {
-						$objExc->IncrementOffset();
-						throw $objExc;
-					}
-			}
-		}


### PR DESCRIPTION
Completing the move to getters and setters for all types of objects we are looking for.

Fixed a problem with Get(Prop)Array on array expansions. Trying to get the property was causing it to look for the corresponding "get" function, which was getting the data all over again, and ignoring conditional expansion data.