### PR TITLE
bugfix-RemoveChildControl

### DIFF
--- a/includes/base_controls/QControlBase.class.php
+++ b/includes/base_controls/QControlBase.class.php
@@ -639,16 +639,16 @@
 		 * @param boolean $blnRemoveFromForm should the control be removed from the form, too?
 		 */
 		public function RemoveChildControl($strControlId, $blnRemoveFromForm) {
-			$this->blnModified = true;	// TODO: Find a way to remove control in javascript so we don't have to redraw the entire control
-										// Its a bit tricky because of the recursive nature of this function
+			$this->blnModified = true;
+			if ($blnRemoveFromForm) {
+				$this->objForm->RemoveControl($strControlId); // will call back to here with $blnRemoveFromForm = false
+			} else {
+				if (isset($this->objChildControlArray[$strControlId])) {
+					$objChildControl = $this->objChildControlArray[$strControlId];
+					$objChildControl->objParentControl = null;
+					unset($this->objChildControlArray[$strControlId]);
+				}
 
-			if (isset($this->objChildControlArray[$strControlId])) {
-				$objChildControl = $this->objChildControlArray[$strControlId];
-				$objChildControl->objParentControl = null;
-				unset($this->objChildControlArray[$strControlId]);
-
-				if ($blnRemoveFromForm)
-					$this->objForm->RemoveControl($objChildControl->ControlId);
 			}
 		}
 


### PR DESCRIPTION
Removing the control was being called too many times for child controls. This is more efficient, in that child controls of child controls only get removed once.