### PR TITLE
bugfix-APCuCache.

### DIFF
--- a/includes/framework/QCacheProviderAPCu.class.php
+++ b/includes/framework/QCacheProviderAPCu.class.php
@@ -1,0 +1,55 @@
+<?php
+
+	
+	/**
+	 * Cache provider based on APC interface. APC or APCu can be used.
+	 * APC and APCu are not included in standard PHP, but are easily added with a pecl install.
+	 */
+	class QCacheProviderAPCu extends QAbstractCacheProvider {
+		/** @var int The lifetime of cached items. */
+		public static $ttl = 86400; // one day between cache drops
+
+
+		/**
+		 * Get the object that has the given key from the cache
+		 * @param string $strKey the key of the object in the cache
+		 * @return object
+		 */
+		public function Get($strKey) {
+			return apcu_fetch($strKey);
+		}
+
+		/**
+		 * Set the object into the cache with the given key
+		 *
+		 * @param string $strKey                the key to use for the object
+		 * @param object $objValue              the object to put in the cache
+		 * @param int    $intExpireAfterSeconds Number of seconds after which the object has to expire
+		 *
+		 * @return void
+		 */
+		public function Set($strKey, $objValue, $intExpireAfterSeconds = null) {
+			if(!is_null($intExpireAfterSeconds)) {
+				apcu_store ($strKey, $objValue, (int)$intExpireAfterSeconds);
+			} else {
+				apcu_store($strKey, $objValue, static::$ttl);
+			}
+		}
+
+		/**
+		 * Delete the object that has the given key from the cache
+		 * @param string $strKey the key of the object in the cache
+		 * @return void
+		 */
+		public function Delete($strKey) {
+			apcu_delete($strKey);
+		}
+
+		/**
+		 * Invalidate all the objects in the cache
+		 * @return void
+		 */
+		public function DeleteAll() {
+			apcu_clear_cache('user');
+		}
+	}

--- a/includes/qcubed.inc.php
+++ b/includes/qcubed.inc.php
@@ -135,6 +135,7 @@
 	QApplicationBase::$ClassFile['qcacheprovidernocache'] = __QCUBED_CORE__ . '/framework/QCacheProviderNoCache.class.php';
 	QApplicationBase::$ClassFile['qcacheproviderredis'] = __QCUBED_CORE__ . '/framework/QCacheProviderRedis.class.php';
 	QApplicationBase::$ClassFile['qcacheproviderapc'] = __QCUBED_CORE__ . '/framework/QCacheProviderAPC.class.php';
+	QApplicationBase::$ClassFile['qcacheproviderapcu'] = __QCUBED_CORE__ . '/framework/QCacheProviderAPCu.class.php';
 	QApplicationBase::$ClassFile['qmultilevelcacheprovider'] = __QCUBED_CORE__ . '/framework/QMultiLevelCacheProvider.class.php';
 	QApplicationBase::$ClassFile['qdbbackedsessionhandler'] = __QCUBED_CORE__ . '/framework/QDbBackedSessionHandler.class.php';
 


### PR DESCRIPTION
The APCu interface has changed. Need to have an apcu only cache.

On PHP7 I was getting apc_fetch function not defined. Its been changed to apcu_fetch. We need the old one still because HHVM has not made the switch yet.