### PR TITLE
InsertOrUpdate now returns the autoincremented ID

### DIFF
--- a/includes/database/QMySqliDatabase.class.php
+++ b/includes/database/QMySqliDatabase.class.php
@@ -52,20 +52,23 @@ if (!defined('MYSQLI_ON_UPDATE_NOW_FLAG')) {
 			return null;
 		}
 
-		public function InsertOrUpdate($strTable, $mixColumnsAndValuesArray, $strPKNames = null) {
-			$strEscapedArray = $this->EscapeIdentifiersAndValues($mixColumnsAndValuesArray);
+		public function InsertOrUpdate($strTable, $mixColumnsAndValuesArray, $strPKName = 'id') {
+			$strEscapedArray	= $this->EscapeIdentifiersAndValues($mixColumnsAndValuesArray);
 			$strUpdateStatement = '';
 			foreach ($strEscapedArray as $strColumn => $strValue) {
-				if ($strUpdateStatement) $strUpdateStatement .= ', ';
+				if ($strUpdateStatement) {
+					$strUpdateStatement .= ', ';
+				}
 				$strUpdateStatement .= $strColumn . ' = ' . $strValue;
 			}
-			$strSql = sprintf('INSERT INTO %s%s%s (%s) VALUES (%s) ON DUPLICATE KEY UPDATE %s',
-				$this->EscapeIdentifierBegin, $strTable, $this->EscapeIdentifierEnd,
-				implode(', ', array_keys($strEscapedArray)),
-				implode(', ', array_values($strEscapedArray)),
-				$strUpdateStatement
-			);
-			$this->ExecuteNonQuery($strSql);
+			
+			$strSql = "INSERT INTO $this->EscapeIdentifierBegin$strTable$this->EscapeIdentifierEnd "
+					. "SET $strUpdateStatement "
+					. "ON DUPLICATE KEY UPDATE $strPKName=LAST_INSERT_ID($strPKName), $strUpdateStatement";
+			
+			$this->NonQuery($strSql);
+			
+			return $this->InsertId($strTable, $strPKName);			
 		}
 
 		public function Connect() {


### PR DESCRIPTION
InsertOrUpdate is a great method that is currently only used by the dbsessionhandler. It allows you to remove a query to determine if you want to insert or update because mysql will do this for you. 
Unfortunately, when you use this method, you didn't get the LAST_INSERT_ID on insert. I added this, plus when there is a duplicate, qcubed will return the id found in the update. 

To simplify the INSERT statement I also used the alternative INSERT syntax. INSERT INTO tablename SET col=val in stead of INSERT INTO tablename (col) values(val)

I'm running dbbackedsessionhandler in production.and it sees no difference between the old and new function. So there shouldn't be an impact on the rest of qcubed.