### PR TITLE
Adding Distinct flag to aggregated methods

### DIFF
--- a/includes/framework/QQuery.class.php
+++ b/includes/framework/QQuery.class.php
@@ -1534,24 +1534,24 @@
 			return new QQHavingClause($objNode);
 		}
 
-		static public function Count(QQColumnNode $objNode, $strAttributeName) {
-			return new QQCount($objNode, $strAttributeName);
+		static public function Count(QQColumnNode $objNode, $strAttributeName, $blnDistinct=false) {
+			return new QQCount($objNode, $strAttributeName, $blnDistinct);
 		}
 
-		static public function Sum(QQColumnNode $objNode, $strAttributeName) {
-			return new QQSum($objNode, $strAttributeName);
+		static public function Sum(QQColumnNode $objNode, $strAttributeName, $blnDistinct=false) {
+			return new QQSum($objNode, $strAttributeName, $blnDistinct);
 		}
 
-		static public function Minimum(QQColumnNode $objNode, $strAttributeName) {
-			return new QQMinimum($objNode, $strAttributeName);
+		static public function Minimum(QQColumnNode $objNode, $strAttributeName, $blnDistinct=false) {
+			return new QQMinimum($objNode, $strAttributeName, $blnDistinct);
 		}
 
-		static public function Maximum(QQColumnNode $objNode, $strAttributeName) {
-			return new QQMaximum($objNode, $strAttributeName);
+		static public function Maximum(QQColumnNode $objNode, $strAttributeName, $blnDistinct=false) {
+			return new QQMaximum($objNode, $strAttributeName, $blnDistinct);
 		}
 
-		static public function Average(QQColumnNode $objNode, $strAttributeName) {
-			return new QQAverage($objNode, $strAttributeName);
+		static public function Average(QQColumnNode $objNode, $strAttributeName, $blnDistinct=false) {
+			return new QQAverage($objNode, $strAttributeName, $blnDistinct);
 		}
 
 		static public function Expand(QQNode $objNode, QQCondition $objJoinCondition = null, QQSelect $objSelect = null) {
@@ -2278,13 +2278,15 @@
 		protected $objNode;
 		protected $strAttributeName;
 		protected $strFunctionName;
-		public function __construct(QQColumnNode $objNode, $strAttributeName) {
+		protected $blnDistinct=false;
+		public function __construct(QQColumnNode $objNode, $strAttributeName, $blnDistinct=false) {
+			$this->blnDistinct = $blnDistinct;
 			$this->objNode = QQ::Func($this->strFunctionName, $objNode);
 			$this->strAttributeName = QQ::GetVirtualAlias($strAttributeName); // virtual attributes are queried lower case
 		}
 		public function UpdateQueryBuilder(QQueryBuilder $objBuilder) {
 			$objBuilder->SetVirtualNode($this->strAttributeName, $this->objNode);
-			$objBuilder->AddSelectFunction(null, $this->objNode->GetColumnAlias($objBuilder), $this->strAttributeName);
+			$objBuilder->AddSelectFunction(null, ($this->blnDistinct ? 'DISTINCT ': ''). $this->objNode->GetColumnAlias($objBuilder), $this->strAttributeName);
 		}
 	}
 	class QQCount extends QQAggregationClause {


### PR DESCRIPTION
You cannot SUM or COUNT DISTINCT values using a GROUP BY with QCubed. Yes there is a DISTINCT, but not on an aggregated level.

To allow this, I've added a blnDistinct flag (by default this is FALSE to avoid breaking stuff).
You can now do 
`QQ::Sum(QQN::Task()->Time,"sum_time",true); // resolves to SUM(DISTINCT t0.time) AS sum_time`

`QQ::Sum(QQN::Task()->Time,"sum_time"); //-> still resolves to SUM(t0.time) AS sum_time`