### PR TITLE
feature - DisplayByteSize

### DIFF
--- a/includes/framework/QString.class.php
+++ b/includes/framework/QString.class.php
@@ -443,4 +443,26 @@
 				)
 				, 0, $intLength);
 		}
+
+		/**
+		 * Convert file size in bytes to human readable
+		 *
+		 * @param  integer  $intSize
+		 * @param  integer $intPrecision
+		 * @return  integer
+		 */
+		public static function DisplayByteSize($intSize, $intPrecision = null) {
+			if (is_null($intSize)) return 'n/a';
+			if ($intSize == 0) return '0 KB';
+			if ($intSize < 0) return '-';
+
+			if ($intSize > 0) {
+				$intSize = (int) $intSize;
+				$base = log($intSize) / log(1024);
+				$suffixes = array(' bytes', ' KB', ' MB', ' GB', ' TB');
+				return round(pow(1024, $base - floor($base)), $intPrecision) . $suffixes[floor($base)];
+			} else {
+				return $intSize;
+			}
+		}
   }


### PR DESCRIPTION
Files or image file sizes in bytes are very uncomfortable to read or calculate. The function is created for human readability.
Example:
`$this->lblMessage->Text = 'Thanks for uploading the file: ' . $this->flaSample->FileName . ". File size: " . QString::DisplayByteSize($this->flaSample->Size, 2);`
