### PR TITLE
$strFormId is useless

### DIFF
--- a/includes/base_controls/QFormBase.class.php
+++ b/includes/base_controls/QFormBase.class.php
@@ -94,6 +94,10 @@
 		 */
 		public static $FormStateHandler = 'QFormStateHandler';
 
+		
+		public function __toString() {
+			return (string) $this->strFormId;
+		}
 		/////////////////////////
 		// Public Properties: GET
 		/////////////////////////
@@ -1181,7 +1185,7 @@
 				// Calling a static method in a class
 				$f = explode('::', $strMethodName);
 				if (is_callable($f)) {
-					$f($this->strFormId, $params['controlId'], $params['param'], $params);
+					$f($this, $params['controlId'], $params['param'], $params);
 				}
 			}
 			elseif (($intPosition = strpos($strMethodName, ':')) !== false) {
@@ -1191,7 +1195,7 @@
 				$objDestControl = $this->objControlArray[$strDestControlId];
 				QControl::_CallActionMethod ($objDestControl, $strMethodName, $this->strFormId, $params);
 			} else {
-				$this->$strMethodName($this->strFormId, $params['controlId'], $params['param'], $params);
+				$this->$strMethodName($this, $params['controlId'], $params['param'], $params);
 			}
 		}
 


### PR DESCRIPTION
$strFormId is useless. I think @spekary already tried to refactor some of it. 
With this commit I try to remove strFormId and pass the object itself. 

A possible use case is requesting a control by strControlId in a static method call. This is currently impossible, but after this commit you have the objFormId and can actually do this. 
I have also added a __toString() method in an attempt to save backwards compatibility. If someone does use the strFormId, it gets string cast automatically.