### PR TITLE
Let GenerateAggregate run, even if we have errors

### DIFF
--- a/assets/php/_devtools/codegen.php
+++ b/assets/php/_devtools/codegen.php
@@ -72,11 +72,10 @@
 		<?php } ?>
 
 		<?php
-			if (!$strErrors) {
 				foreach (QCodeGen::GenerateAggregate() as $strMessage) { ?>
 					<p><strong><?php _p($strMessage); ?></strong></p>
 				<?php }
-			} ?>
+			 ?>
 	</div>
 
 <?php require(__CONFIGURATION__ . '/footer.inc.php'); ?>


### PR DESCRIPTION
Some errors aren't fatal, and GenerateAggregate is perfectly capable of handling those errors (see issue #1249)