### PR TITLE
Ignore parent- and self-links when iterating Dir()

### DIFF
--- a/includes/qform_state_handlers/QFileFormStateHandler.class.php
+++ b/includes/qform_state_handlers/QFileFormStateHandler.class.php
@@ -87,7 +87,7 @@
 			$objDirectory = dir(self::$StatePath);
 			while (($strFile = $objDirectory->read()) !== false) {
 				if (($strFile==".")||($strFile=="..")) continue;
-				if (!$FileNamePrefix)
+				if (!$self::FileNamePrefix)
 					$intPosition = 0;
 				else
 					$intPosition = strpos($strFile, self::$FileNamePrefix);

--- a/includes/qform_state_handlers/QFileFormStateHandler.class.php
+++ b/includes/qform_state_handlers/QFileFormStateHandler.class.php
@@ -86,7 +86,8 @@
 			// Go through all the files
 			$objDirectory = dir(self::$StatePath);
 			while (($strFile = $objDirectory->read()) !== false) {
-				if (!count(self::$FileNamePrefix))
+				if (($strFile==".")||($strFile=="..")) continue;
+				if (!$FileNamePrefix)
 					$intPosition = 0;
 				else
 					$intPosition = strpos($strFile, self::$FileNamePrefix);


### PR DESCRIPTION
Code fails attempting to unlink() the parent/self links.